### PR TITLE
feat: add header account dropdown and scenario delete confirmation

### DIFF
--- a/frontend/src/components/Header/UserProfileSection.tsx
+++ b/frontend/src/components/Header/UserProfileSection.tsx
@@ -1,6 +1,14 @@
+import { useCallback, useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import { FiLogIn } from "react-icons/fi";
+import { LuUser, LuLogOut } from "react-icons/lu";
+import { Dropdown, type MenuProps } from "antd";
+
 import { GuideStepsEnums } from "@context/guideContext";
 import GuideOverlay from "@components/ui/GuideOverlay";
+import { UserContext } from "@context/userContext";
+import { AuthService } from "@services/authService";
+import { ROUTES } from "@constants/routes";
 import { UserDetails } from "./types";
 import { UserIcon } from "./UserIcon";
 
@@ -10,6 +18,41 @@ interface UserProfileSectionProps {
 }
 
 export const UserProfileSection = ({ userDetails, onLoginClick }: UserProfileSectionProps) => {
+    const navigate = useNavigate();
+    const { refreshUser } = useContext(UserContext);
+
+    const handleLogout = useCallback(async () => {
+        try {
+            await AuthService.logout();
+        } catch (error) {
+            console.error("Logout failed:", error);
+        } finally {
+            try {
+                await refreshUser();
+            } catch (refreshError) {
+                console.error("Failed to refresh user after logout:", refreshError);
+            }
+            navigate(ROUTES.HOME);
+        }
+    }, [navigate, refreshUser]);
+
+    const menuItems: MenuProps["items"] = [
+        {
+            key: "profile",
+            label: "Profile",
+            icon: <LuUser className="text-base" />,
+            onClick: onLoginClick,
+        },
+        { type: "divider" },
+        {
+            key: "logout",
+            label: "Logout",
+            icon: <LuLogOut className="text-base" />,
+            danger: true,
+            onClick: handleLogout,
+        },
+    ];
+
     return (
         <div className="relative flex items-center">
             {userDetails ? (
@@ -25,20 +68,33 @@ export const UserProfileSection = ({ userDetails, onLoginClick }: UserProfileSec
                 instruction="Step 1: Go to your Profile"
                 handleGoClick={onLoginClick}
             >
-                <button
-                    onClick={onLoginClick}
-                    className="flex items-center focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-1 rounded-full transition-all duration-200"
-                    title={userDetails ? "Profile" : "Login"}
-                >
-                    {userDetails ? (
-                        <UserIcon user={userDetails} />
-                    ) : (
+                {userDetails ? (
+                    <Dropdown
+                        menu={{ items: menuItems }}
+                        trigger={["click"]}
+                        placement="bottomRight"
+                    >
+                        <button
+                            type="button"
+                            className="flex items-center focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-1 rounded-full transition-all duration-200"
+                            title="Account menu"
+                        >
+                            <UserIcon user={userDetails} />
+                        </button>
+                    </Dropdown>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={onLoginClick}
+                        className="flex items-center focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-1 rounded-full transition-all duration-200"
+                        title="Login"
+                    >
                         <div className="h-9 flex items-center gap-1.5 border border-sky-300 text-sky-600 bg-sky-50 rounded-full px-4 text-sm font-medium hover:bg-sky-100 hover:border-sky-500 transition-all duration-200">
                             <FiLogIn className="text-base" />
                             <span>Login</span>
                         </div>
-                    )}
-                </button>
+                    </button>
+                )}
             </GuideOverlay>
         </div>
     );

--- a/frontend/src/pages/user-profile/index.tsx
+++ b/frontend/src/pages/user-profile/index.tsx
@@ -1,17 +1,9 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-    LuLogOut,
-    LuExternalLink,
-    LuUser,
-    LuSettings,
-    LuBookmark,
-    LuFileText,
-} from "react-icons/lu";
+import { LuExternalLink, LuUser, LuSettings, LuBookmark, LuFileText } from "react-icons/lu";
 
 import { UserContext } from "@context/userContext";
 import JsonDataForm from "@components/registry-components/subscriber-form";
-import { AuthService } from "@services/authService";
 import { authTokenManager } from "@utils/localStorageManager";
 import ScenarioPreferencesForm from "./scenario-preferences-form";
 import PastReportsSection from "./past-reports-section";
@@ -55,21 +47,6 @@ const UserProfile = () => {
         }
     }, [navigate, userDetails]);
 
-    const handleLogout = useCallback(async () => {
-        try {
-            await AuthService.logout();
-        } catch (error) {
-            console.error("Logout failed:", error);
-        } finally {
-            try {
-                await refreshUser();
-            } catch (refreshError) {
-                console.error("Failed to refresh user after logout:", refreshError);
-            }
-            navigate(ROUTES.HOME);
-        }
-    }, [navigate, refreshUser]);
-
     const scrollTo = (id: string) => {
         if (id === "add-scenario-config") {
             setScenarioFormTrigger((t) => t + 1);
@@ -106,7 +83,7 @@ const UserProfile = () => {
                             </p>
                         )}
                         <p className="text-xs font-semibold text-sky-200 uppercase tracking-widest mt-3">
-                            Navigation
+                            Account
                         </p>
                     </div>
 
@@ -156,29 +133,14 @@ const UserProfile = () => {
                 >
                     <h1 className="text-3xl font-bold text-gray-900 mb-4 mt-4">User Profile</h1>
                     <div className="max-w-4xl mx-auto p-6 bg-white rounded-xl">
-                        <div className="flex items-center gap-6">
-                            {/* User info */}
-                            <div className="flex-1 text-left text-gray-700 space-y-1">
-                                <p>
-                                    <strong>Login:</strong> {userDetails?.username || "N/A"}
-                                </p>
-                                <p>
-                                    <strong>Participant ID:</strong>{" "}
-                                    {userDetails?.participantId || "N/A"}
-                                </p>
-                            </div>
-
-                            {/* Logout */}
-                            <div className="shrink-0">
-                                <button
-                                    type="button"
-                                    className="px-4 py-2 bg-sky-600 text-white rounded hover:bg-sky-800 flex items-center gap-2"
-                                    onClick={handleLogout}
-                                >
-                                    <LuLogOut className="text-lg" />
-                                    <strong>Logout</strong>
-                                </button>
-                            </div>
+                        <div className="text-left text-gray-700 space-y-1">
+                            <p>
+                                <strong>Login:</strong> {userDetails?.username || "N/A"}
+                            </p>
+                            <p>
+                                <strong>Participant ID:</strong>{" "}
+                                {userDetails?.participantId || "N/A"}
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/user-profile/scenario-preferences-form.tsx
+++ b/frontend/src/pages/user-profile/scenario-preferences-form.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
-import { LuPlus, LuX } from "react-icons/lu";
+import { LuPlus, LuX, LuTriangleAlert } from "react-icons/lu";
+import { Modal } from "antd";
 
 import { FormInput } from "@components/ui/forms/form-input";
 import FormSelect from "@components/ui/forms/form-select";
@@ -226,6 +227,31 @@ export default function ScenarioPreferencesForm({ externalOpenTrigger = 0 }: Pro
         }
     };
 
+    const confirmDelete = (configKey: string) => {
+        Modal.confirm({
+            title: "Delete configuration",
+            icon: <LuTriangleAlert className="text-xl mr-2" style={{ color: "#ef4444" }} />,
+            content: (
+                <span>
+                    Are you sure you want to delete{" "}
+                    <span className="font-semibold text-gray-900">{configKey}</span>? This action
+                    cannot be undone.
+                </span>
+            ),
+            okText: "Delete",
+            cancelText: "Cancel",
+            centered: true,
+            okButtonProps: {
+                style: {
+                    backgroundColor: "#ef4444",
+                    borderColor: "#ef4444",
+                    color: "#fff",
+                },
+            },
+            onOk: () => handleDelete(configKey),
+        });
+    };
+
     return (
         <div className="bg-gray-100 p-2 rounded-md shadow-sm mt-4">
             <h2 className="text-xl font-bold text-gray-900 mb-1 mt-2">
@@ -276,7 +302,7 @@ export default function ScenarioPreferencesForm({ externalOpenTrigger = 0 }: Pro
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    onClick={() => handleDelete(key)}
+                                                    onClick={() => confirmDelete(key)}
                                                     className="text-red-400 hover:text-red-600 text-sm font-medium"
                                                 >
                                                     Delete


### PR DESCRIPTION
## What does this PR do?
feat: add account dropdown menu and delete confirmation modal

- Move logout action from user profile page into a dropdown menu on the header's UserProfileSection (Profile + Logout)
- Remove the inline Logout button and relabel the sidebar "Navigation" section as "Account"
- Add a confirmation modal before deleting a scenario configuration in ScenarioPreferencesForm

## Type of change
- [ ] feat — new feature

## How has this been tested?
manual steps 

## Related issue
Closes #
