### PR TITLE
feat(form): resolve session data from transaction_id in checkFormCompletion

### DIFF
--- a/backend/src/controllers/flowController.ts
+++ b/backend/src/controllers/flowController.ts
@@ -1,4 +1,3 @@
-// FILE: uiController.ts
 import { Request, Response } from "express";
 import { fetchConfigService } from "../services/flowService";
 import { updateFlowService } from "../services/sessionService";
@@ -12,6 +11,7 @@ import logger from "@ondc/automation-logger";
 import { saveLog } from "../utils/console";
 import { buildMockBaseURL } from "../utils";
 import { getLoggerMeta } from "../utils/logger-meta-utilts";
+import { RedisService } from "ondc-automation-cache-lib";
 
 export const fetchConfig = (req: Request, res: Response) => {
 	try {
@@ -280,6 +280,20 @@ export const newFlow = async (req: Request, res: Response) => {
 				"X-Request-ID": req.correlationId,
 			},
 		});
+
+		// Write reverse-index so controllers that only have transaction_id
+		// (e.g. checkFormCompletion) can resolve the parent session.
+		// TTL matches SESSION_EXPIRY (24 h).
+		await RedisService.setKey(
+			`txn:session:${transaction_id}`,
+			session_id,
+			3600 * 24,
+		);
+		logger.debug("Reverse-index key written", {
+			key: `txn:session:${transaction_id}`,
+			session_id,
+		});
+
 		res.status(response.status).send(response.data);
 	} catch (e) {
 		logger.error(

--- a/backend/src/controllers/formController.ts
+++ b/backend/src/controllers/formController.ts
@@ -1,6 +1,8 @@
 import { Request, Response, RequestHandler } from 'express';
 import { RedisService } from 'ondc-automation-cache-lib';
 import logger from '@ondc/automation-logger';
+import { getSessionByTransactionId } from '../services/sessionService';
+import { SessionCache } from '../interfaces/newSessionData';
 
 /**
  * Check if form callback has been received
@@ -21,6 +23,28 @@ export const checkFormCompletion: RequestHandler = async (req: Request, res: Res
       return;
     }
 
+    // Fetch session data via reverse-index (txn:session:{transaction_id} -> sessionId)
+    // Non-fatal: a missing entry means the flow pre-dates this index or was never registered.
+    const sessionData: SessionCache | null = await getSessionByTransactionId(
+      transaction_id as string
+    );
+    if (sessionData) {
+      logger.info('Session data resolved for form completion check', {
+        transaction_id,
+        form_id,
+        domain: sessionData.domain,
+        subscriberUrl: sessionData.subscriberUrl,
+        npType: sessionData.npType,
+        sessionData,
+      });
+    } else {
+      logger.warning('Could not resolve session for transaction_id', {
+        transaction_id,
+        form_id,
+      });
+    }
+
+    
     const completionKey = `form_completed:${transaction_id}:${form_id}`;
     const completionData = await RedisService.getKey(completionKey);
 

--- a/backend/src/services/sessionService.ts
+++ b/backend/src/services/sessionService.ts
@@ -365,6 +365,28 @@ export const requestForFlowPermissionService = async (
 	};
 };
 
+export const getSessionByTransactionId = async (
+	transactionId: string,
+): Promise<SessionCache | null> => {
+	try {
+		const sessionId = await RedisService.getKey(`txn:session:${transactionId}`);
+		if (!sessionId) {
+			logger.debug("No reverse-index entry found for transaction", {
+				transactionId,
+			});
+			return null;
+		}
+		return await getSessionService(sessionId);
+	} catch (e: any) {
+		logger.error(
+			"Error fetching session by transactionId",
+			{ transactionId },
+			e,
+		);
+		return null;
+	}
+};
+
 export const updateFlowService = async (
 	sessionId: string,
 	flows: any[],


### PR DESCRIPTION
- Add getSessionByTransactionId() to sessionService — two-hop Redis lookup via reverse-index key txn:session:{transactionId} -> sessionId
- Write reverse-index key in newFlow (flowController) with 24h TTL so any controller with only a transaction_id can resolve the parent session
- In checkFormCompletion, fetch and log full SessionCache before the completionKey check; non-fatal if index entry is missing (old flows)

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [x] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
