### PR TITLE
feat(backend): session-keyed form completion + save-redirection endpoint

### DIFF
--- a/backend/src/controllers/formController.ts
+++ b/backend/src/controllers/formController.ts
@@ -2,79 +2,59 @@ import { Request, Response, RequestHandler } from 'express';
 import { RedisService } from 'ondc-automation-cache-lib';
 import logger from '@ondc/automation-logger';
 
-// Key prefixes form a cross-service contract with the api-service's
-// callbackFormService (which writes them) — keep in sync.
+// Key prefixes form a cross-service contract with the api-service GET /callback
+// (which writes form_completed and reads redirection_url) — keep in sync.
+//
+//   form_completed:{session_id}      -> completion payload   (written by callback)
+//   redirection_url:{subscriberUrl}  -> full workbench URL    (written here)
+//
+// Everything is session/subscriber-scoped — no transaction_id or form_id.
 const FORM_COMPLETED_PREFIX = 'form_completed';
-const LATEST_FORM_PREFIX = 'latest_form';
+const REDIRECTION_URL_PREFIX = 'redirection_url';
+const REDIRECTION_URL_TTL_SECONDS = 3600;
 
-// After the first successful read, completion keys are re-armed with this TTL
-// instead of being deleted, so every session polling the same transaction
-// (buyer AND seller workbench sessions) can observe the completion before it
-// self-cleans.
+// After the first successful read, the completion key is re-armed with this TTL
+// instead of being deleted, so a slightly-later poll on the same session can
+// still observe the completion before it self-cleans.
 const CONSUMED_TTL_SECONDS = 60;
 
 /**
- * Check if form callback has been received
- * Polled by the frontend after user submits form in popup
- * GET /form/check-completion?transaction_id=X[&form_id=Y]
+ * Check if the form callback has been received for a session.
+ * Polled by the frontend after the form fires the callback.
+ * GET /form/check-completion?session_id=X
  *
- * The api-service writes two keys on callback:
- *   form_completed:{transaction_id}:{form_id} -> completion payload
- *   latest_form:{transaction_id}              -> form_id (pointer)
- * If form_id is not supplied by the caller, it is resolved via the pointer.
+ * The api-service GET /callback writes form_completed:{session_id}.
  */
 export const checkFormCompletion: RequestHandler = async (req: Request, res: Response) => {
   try {
-    const { transaction_id } = req.query;
-    let { form_id } = req.query;
+    const { session_id } = req.query;
 
-    logger.info('Form completion check', { transaction_id, form_id });
+    logger.info('Form completion check', { session_id });
 
-    if (!transaction_id) {
+    if (!session_id) {
       res.status(400).json({
-        error: 'transaction_id is required',
+        error: 'session_id is required',
         completed: false
       });
       return;
     }
 
-    if (!form_id) {
-      const pointerKey = `${LATEST_FORM_PREFIX}:${transaction_id}`;
-      const latestFormId = await RedisService.getKey(pointerKey);
-      if (!latestFormId) {
-        logger.debug('Form completion check: PENDING (no callback yet)', { transaction_id });
-        res.json({ completed: false });
-        return;
-      }
-      form_id = latestFormId;
-    }
-
-    const completionKey = `${FORM_COMPLETED_PREFIX}:${transaction_id}:${form_id}`;
+    const completionKey = `${FORM_COMPLETED_PREFIX}:${session_id}`;
     const completionData = await RedisService.getKey(completionKey);
 
     if (completionData) {
       const data = JSON.parse(completionData);
       logger.info('Form completion check: COMPLETED', {
-        transaction_id,
-        form_id,
+        session_id,
         timestamp: data.timestamp
       });
 
-      // Re-arm both keys with a short TTL instead of deleting them: the buyer
-      // and seller workbench sessions poll this endpoint with the same
-      // transaction_id, and each must observe the completion. Multi-form
-      // transactions still start clean because DynamicFormHandler calls
-      // POST /form/reset-completion before it begins polling.
-      await RedisService.setKey(
-        `${LATEST_FORM_PREFIX}:${transaction_id}`,
-        String(form_id),
-        CONSUMED_TTL_SECONDS
-      );
+      // Re-arm with a short TTL instead of deleting, so a slightly-later poll on
+      // the same session still observes the completion before it self-cleans.
       await RedisService.setKey(completionKey, completionData, CONSUMED_TTL_SECONDS);
 
       res.json({
         completed: true,
-        form_id,
         success: data.success,
         message: data.message,
         timestamp: data.timestamp
@@ -82,12 +62,7 @@ export const checkFormCompletion: RequestHandler = async (req: Request, res: Res
       return;
     }
 
-    // Pointer existed but completion data did not — should not happen given the
-    // api-service writes completion data before the pointer.
-    logger.warning('Form completion check: pointer found but completion data missing', {
-      transaction_id,
-      form_id
-    });
+    logger.debug('Form completion check: PENDING (no callback yet)', { session_id });
     res.json({ completed: false });
 
   } catch (error: any) {
@@ -101,33 +76,77 @@ export const checkFormCompletion: RequestHandler = async (req: Request, res: Res
 };
 
 /**
- * Clear any leftover form completion for a transaction
- * Called by the frontend BEFORE it starts polling, so a completion left
- * over from an earlier form in the same transaction (e.g. the user closed
- * the tab without the poll consuming it) cannot satisfy the new poll.
- * POST /form/reset-completion?transaction_id=X
+ * Save the workbench tab URL to redirect back to after the form callback.
+ * Keyed by the subscriberUrl embedded in the workbench URL, because the
+ * api-service GET /callback has no session_id — it derives its own subscriberUrl
+ * (from {subscriberUrl}/callback), looks this up, and parses sessionId out of
+ * the stored URL.
+ * POST /form/save-redirection   body: { redirection_url }
  */
-export const resetFormCompletion: RequestHandler = async (req: Request, res: Response) => {
+export const saveRedirectionUrl: RequestHandler = async (req: Request, res: Response) => {
   try {
-    const { transaction_id } = req.query;
+    const { redirection_url } = req.body ?? {};
 
-    if (!transaction_id) {
-      res.status(400).json({ error: 'transaction_id is required' });
+    if (!redirection_url || typeof redirection_url !== 'string') {
+      res.status(400).json({ error: 'redirection_url is required' });
       return;
     }
 
-    const pointerKey = `${LATEST_FORM_PREFIX}:${transaction_id}`;
-    const formId = await RedisService.getKey(pointerKey);
-
-    if (formId) {
-      // Delete via the pointer — the poll path resolves through it, so no
-      // scan over form_completed:{txn}:* is needed.
-      await RedisService.deleteKey(`${FORM_COMPLETED_PREFIX}:${transaction_id}:${formId}`);
-      await RedisService.deleteKey(pointerKey);
-      logger.info('Form completion state reset', { transaction_id, form_id: formId });
-    } else {
-      logger.debug('Form completion reset: nothing to clear', { transaction_id });
+    // Open-redirect guard: only store http(s) URLs (a browser is later sent here).
+    let parsed: URL;
+    try {
+      parsed = new URL(redirection_url);
+    } catch {
+      res.status(400).json({ error: 'redirection_url is not a valid URL' });
+      return;
     }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      res.status(400).json({ error: 'redirection_url must be http(s)' });
+      return;
+    }
+
+    // The workbench URL carries both ids as query params; subscriberUrl is the
+    // Redis key, sessionId is what the callback parses out at read time.
+    const subscriberUrl = parsed.searchParams.get('subscriberUrl');
+    const sessionId = parsed.searchParams.get('sessionId');
+    if (!subscriberUrl || !sessionId) {
+      res.status(400).json({
+        error: 'redirection_url must contain subscriberUrl and sessionId query params'
+      });
+      return;
+    }
+
+    await RedisService.setKey(
+      `${REDIRECTION_URL_PREFIX}:${subscriberUrl}`,
+      redirection_url,
+      REDIRECTION_URL_TTL_SECONDS
+    );
+    logger.info('Redirection URL saved', { subscriberUrl, sessionId });
+
+    res.json({ saved: true });
+  } catch (error: any) {
+    logger.error('Error saving redirection url', error);
+    res.status(500).json({ error: 'Failed to save redirection url', message: error.message });
+  }
+};
+
+/**
+ * Clear any leftover form completion for a session.
+ * Called by the frontend BEFORE it starts polling, so a stale completion from
+ * an earlier run on the same session cannot satisfy the new poll.
+ * POST /form/reset-completion?session_id=X
+ */
+export const resetFormCompletion: RequestHandler = async (req: Request, res: Response) => {
+  try {
+    const { session_id } = req.query;
+
+    if (!session_id) {
+      res.status(400).json({ error: 'session_id is required' });
+      return;
+    }
+
+    await RedisService.deleteKey(`${FORM_COMPLETED_PREFIX}:${session_id}`);
+    logger.info('Form completion state reset', { session_id });
 
     res.json({ reset: true });
 

--- a/backend/src/routes/form-routes.ts
+++ b/backend/src/routes/form-routes.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
-import { checkFormCompletion, resetFormCompletion } from '../controllers/formController';
+import {
+  checkFormCompletion,
+  resetFormCompletion,
+  saveRedirectionUrl,
+} from '../controllers/formController';
 
 const router = Router();
 
@@ -17,5 +21,13 @@ router.get('/form/check-completion', checkFormCompletion);
  * POST /form/reset-completion?transaction_id=X
  */
 router.post('/form/reset-completion', resetFormCompletion);
+
+/**
+ * Save redirection URL endpoint
+ * Called by the frontend (popup before first on_status) to store the workbench
+ * tab URL; the api-service GET /callback redirects the browser back to it.
+ * POST /form/save-redirection   body: { session_id, redirection_url }
+ */
+router.post('/form/save-redirection', saveRedirectionUrl);
 
 export default router;


### PR DESCRIPTION
- save-redirection (POST /form/save-redirection): stores the workbench URL in redirection_url:{subscriberUrl}, parsed from the URL's query params.
- check-completion / reset-completion: now keyed by session_id (form_completed:{session_id}); dropped transaction_id, form_id and the latest_form pointer. Matches the GET /callback contract in the api-service.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
