### PR TITLE
Port LAMF single-redirection launch popup + session_id form completion from main

### DIFF
--- a/frontend/src/components/FlowShared/mapped-flow.tsx
+++ b/frontend/src/components/FlowShared/mapped-flow.tsx
@@ -3,7 +3,11 @@ import { toast } from "react-toastify";
 import { IoPlay } from "react-icons/io5";
 
 import { FlowMap, MappedStep } from "@/types/flow-state-type";
-import FormConfig, { FormConfigType } from "@components/ui/forms/config-form/config-form";
+import FormConfig, {
+    FormConfigType,
+    FormFieldConfigType,
+} from "@components/ui/forms/config-form/config-form";
+import FormLaunchPopup from "@components/ui/forms/custom-forms/form-launch-popup";
 import Popup from "@components/ui/pop-up/pop-up";
 import CustomTooltip from "@components/ui/mini-components/tooltip";
 import { SequenceStep, SubmitEventParams } from "@/types/flow-types";
@@ -16,6 +20,12 @@ import {
     isTrackingActive,
     isRideMapEnabled,
 } from "@components/FlowShared/ride-map-utils";
+
+// LAMF single-redirection flow: its MANUAL_DYNAMIC_FORM form is launched from a
+// separate one-button popup as soon as the FIRST on_select completes (this flow
+// has a second on_select after on_status — that one must NOT trigger it). Scoped
+// strictly by flow id so no other flow's behavior changes.
+const LAMF_SINGLE_REDIRECTION_FLOW_ID = "lamf_credit_line_with_mfc_single_redirection";
 
 export default function DisplayFlow({
     mappedFlow,
@@ -44,6 +54,15 @@ export default function DisplayFlow({
     const activeInputSigRef = useRef<string | undefined>(undefined);
     const submittedInputSigRef = useRef<string | undefined>(undefined);
 
+    // LAMF single-redirection "launch" popup (separate from the polling popup): a
+    // one-button popup shown when the first on_select completes. It only opens the
+    // form URL + saves the redirection URL, then disappears. It does NOT poll.
+    const [launchPopUp, setLaunchPopUp] = useState(false);
+    const [launchFormConfig, setLaunchFormConfig] = useState<FormFieldConfigType | undefined>(
+        undefined
+    );
+    const launchHandledSigRef = useRef<string | undefined>(undefined);
+
     // User-initiated "extra trigger" popup — kept separate from the auto-open INPUT-REQUIRED popup.
     const [extraPopUp, setExtraPopUp] = useState(false);
     const [extraFormConfig, setExtraFormConfig] = useState<FormConfigType | undefined>(undefined);
@@ -51,6 +70,28 @@ export default function DisplayFlow({
     const [triggeringKey, setTriggeringKey] = useState<string | undefined>(undefined);
 
     const { sessionId, sessionData, activeFlowId, autoScrollEnabled } = useSession();
+
+    const isLamfRedirectionFlow = flowId === LAMF_SINGLE_REDIRECTION_FLOW_ID;
+
+    // Per-run key for the LAMF launch popup's "already handled" marker. Keyed on
+    // the transaction id so it resets only when the flow is cleared (new txn id),
+    // and persisted in localStorage so a page refresh does not re-show the popup.
+    const launchMarkerKey = () => {
+        const txnId = sessionData?.flowMap?.[flowId] ?? "";
+        return `lamf_launch_done:${flowId}:${txnId}`;
+    };
+
+    // Mark the launch as done (button clicked) and dismiss the popup. The marker
+    // persists across refreshes; it clears naturally when the flow is cleared.
+    const handleFormLaunched = () => {
+        try {
+            localStorage.setItem(launchMarkerKey(), "1");
+        } catch {
+            // localStorage unavailable — non-fatal, popup just won't persist.
+        }
+        setLaunchPopUp(false);
+        setLaunchFormConfig(undefined);
+    };
 
     // Auto-scroll bookkeeping: DOM node per step signature, previous poll's status map, and a guard
     // so we don't scroll on the initial mount (everything would look "new").
@@ -79,6 +120,47 @@ export default function DisplayFlow({
         isRideMapEnabled(sessionData?.domain, sessionData?.version) && isTrackingActive(mappedFlow);
 
     useEffect(() => {
+        // LAMF single-redirection: as soon as the FIRST on_select completes (this
+        // flow has a second on_select after on_status — that one must NOT trigger
+        // it), show the separate one-button "launch" popup. Only the BPP session
+        // shows it; it opens the form + saves the redirection URL, then disappears.
+        // The polling popup is untouched and still opens via the normal selection.
+        if (isLamfRedirectionFlow && sessionData?.npType === "BPP") {
+            const firstOnSelect = mappedFlow?.sequence
+                ?.filter((s) => s.actionType === "on_select")
+                ?.sort((a, b) => a.index - b.index)?.[0];
+            const formStep = mappedFlow?.sequence?.find((s) =>
+                s.input?.some((f) => f.type === "MANUAL_DYNAMIC_FORM")
+            );
+            const manualFormField = formStep?.input?.find((f) => f.type === "MANUAL_DYNAMIC_FORM");
+
+            // "Already handled" must survive a page refresh, so it is persisted in
+            // localStorage keyed by the per-run transaction id; it resets only when
+            // the flow is cleared, or once the form step itself is COMPLETE.
+            const markerKey = launchMarkerKey();
+            const alreadyDone = formStep?.status === "COMPLETE" || isLaunchDone(markerKey);
+
+            if (firstOnSelect?.status === "COMPLETE" && manualFormField && !alreadyDone) {
+                if (markerKey !== launchHandledSigRef.current) {
+                    launchHandledSigRef.current = markerKey;
+                    setLaunchFormConfig(manualFormField);
+                    setLaunchPopUp(true);
+                }
+            } else if (firstOnSelect && firstOnSelect.status !== "COMPLETE") {
+                // Flow was (re)started or hasn't reached the form point yet: re-arm
+                // so the popup shows again on the next completion. The per-run
+                // transaction id can be reused, so also clear the persisted marker.
+                // During a live run on_select stays COMPLETE, so this never runs
+                // mid-run — refresh-survival is preserved.
+                launchHandledSigRef.current = undefined;
+                try {
+                    localStorage.removeItem(markerKey);
+                } catch {
+                    // localStorage unavailable — non-fatal.
+                }
+            }
+        }
+
         // Sequence steps (skip first — that's the flow's initial trigger) take priority over extras.
         // MANUAL_DYNAMIC_FORM steps also auto-open on the counterparty side (WAITING-SUBMISSION):
         // both sessions poll the same completion callback, and each clears its own step.
@@ -113,6 +195,28 @@ export default function DisplayFlow({
         // Target moved on (different step or none) — drop the suppression and proceed.
         submittedInputSigRef.current = undefined;
         activeInputSigRef.current = sig;
+
+        // LAMF single-redirection: the BAP side does not wait on the form callback
+        // (completion is keyed by the BPP session, which BAP can't observe). Auto-
+        // proceed past the MANUAL_DYNAMIC_FORM step immediately instead of opening
+        // the polling popup. BPP is unaffected and still drives real completion.
+        if (
+            isLamfRedirectionFlow &&
+            sessionData?.npType === "BAP" &&
+            seqStep?.input?.some((f) => f.type === "MANUAL_DYNAMIC_FORM")
+        ) {
+            if (sessionData?.activeFlow !== flowId) return;
+            submittedInputSigRef.current = sig; // proceed once per status (guards double-fire across polls)
+            const submission_id = crypto.randomUUID();
+            const bapTxId = sessionData?.flowMap?.[flowId] ?? "";
+            // Raise the ordering flag once BAP's proceed resolves, so the waiting
+            // BPP form-step submit can then proceed (BAP-before-BPP at the form step).
+            void handleFormSubmit({
+                jsonPath: { submission_id },
+                formData: { submission_id },
+            }).then(() => markBapProceeded(bapTxId));
+            return;
+        }
 
         if (conf?.length === 0) {
             if (sessionData?.activeFlow !== flowId) return;
@@ -219,6 +323,17 @@ export default function DisplayFlow({
                 console.error("Transaction ID not found");
                 return;
             }
+            // LAMF ordering: the BPP *form step* must not proceed until BAP has
+            // proceeded it first. Scope strictly to the MANUAL_DYNAMIC_FORM submit
+            // (not every form in the flow), else other BPP forms would block too.
+            const isLamfManualFormSubmit =
+                isLamfRedirectionFlow &&
+                sessionData?.npType === "BPP" &&
+                activeFormConfig?.some((f) => f.type === "MANUAL_DYNAMIC_FORM");
+            if (isLamfManualFormSubmit) {
+                await waitForBapProceeded(txId);
+            }
+
             // Pass extraKey explicitly for the immediate auto-submit path (state not yet flushed);
             // popup submissions fall back to the stored key set when the form opened.
             const key = extraKey ?? activeInputExtraKey;
@@ -227,6 +342,7 @@ export default function DisplayFlow({
             } else {
                 await proceedFlow(sessionId, txId, formData.jsonPath, formData.formData);
             }
+
             // Remember what we submitted so the auto-open effect won't re-open it while the
             // backend still reports it as INPUT-REQUIRED on the next poll(s).
             submittedInputSigRef.current = activeInputSigRef.current;
@@ -337,6 +453,16 @@ export default function DisplayFlow({
                     />
                 </Popup>
             )}
+            {launchPopUp && launchFormConfig && (
+                <Popup isOpen={launchPopUp} disableClose>
+                    <FormLaunchPopup
+                        formConfig={launchFormConfig}
+                        referenceData={mappedFlow.reference_data}
+                        sessionId={sessionId}
+                        onLaunched={handleFormLaunched}
+                    />
+                </Popup>
+            )}
             {extraPopUp && extraFormConfig && (
                 <Popup isOpen={extraPopUp} onClose={closeExtraPopUp}>
                     <FormConfig
@@ -402,6 +528,61 @@ export type PairedStep = {
 // differ from each other by actionId.
 function stepSignature(step: MappedStep): string {
     return `${step.missedStep ? "m" : "s"}|${step.actionId}|${step.index}`;
+}
+
+// Whether the LAMF launch popup has already been handled this run (survives refresh).
+function isLaunchDone(markerKey: string): boolean {
+    try {
+        return localStorage.getItem(markerKey) === "1";
+    } catch {
+        return false;
+    }
+}
+
+// LAMF ordering (BAP must proceed the form step before BPP). BAP and BPP share the
+// transaction id and (same browser) localStorage, so BAP raises this per-run flag
+// when it proceeds and BPP waits for it. LAMF-only.
+const BAP_PROCEEDED_PREFIX = "lamf_bap_proceeded";
+
+function markBapProceeded(txId: string): void {
+    try {
+        localStorage.setItem(`${BAP_PROCEEDED_PREFIX}:${txId}`, "1");
+    } catch {
+        // localStorage unavailable — non-fatal.
+    }
+}
+
+// Resolve once BAP has proceeded (flag set), or after a safety timeout so BPP
+// never hangs forever if BAP never ran.
+function waitForBapProceeded(txId: string): Promise<void> {
+    const key = `${BAP_PROCEEDED_PREFIX}:${txId}`;
+    return new Promise((resolve) => {
+        const isSet = () => {
+            try {
+                return localStorage.getItem(key) === "1";
+            } catch {
+                return true; // can't read → don't block
+            }
+        };
+        if (isSet()) {
+            resolve();
+            return;
+        }
+        const start = Date.now();
+        const TIMEOUT_MS = 600_000;
+        const finish = () => {
+            clearInterval(iv);
+            window.removeEventListener("storage", onStorage);
+            resolve();
+        };
+        const onStorage = (e: StorageEvent) => {
+            if (e.key === key && e.newValue === "1") finish();
+        };
+        const iv = setInterval(() => {
+            if (isSet() || Date.now() - start > TIMEOUT_MS) finish();
+        }, 500);
+        window.addEventListener("storage", onStorage);
+    });
 }
 
 // Nearest actually-scrolling ancestor, or null when the window/document is the scroller.

--- a/frontend/src/components/ui/forms/custom-forms/dynamic-form-handler.tsx
+++ b/frontend/src/components/ui/forms/custom-forms/dynamic-form-handler.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import axios from "axios";
-import { SubmitEventParams } from "../../../../types/flow-types";
-import { queryJsonPath } from "../../../../utils/jsonpath-query";
-import { FormFieldConfigType } from "../config-form/config-form";
+import { SubmitEventParams } from "@/types/flow-types";
+import { queryJsonPath } from "@utils/jsonpath-query";
+import { FormFieldConfigType } from "@components/ui/forms/config-form/config-form";
+import { useSession } from "@context/context";
+import { FormService } from "@services/formService";
 
 // ── Polling constants ──────────────────────────────────────────────────────────
 const POLL_INTERVAL_MS = 2_000; // 2 seconds between each poll
@@ -21,9 +22,13 @@ interface DynamicFormHandlerProps {
 export default function DynamicFormHandler({
     submitEvent,
     referenceData,
-    transactionId,
     formConfig,
 }: DynamicFormHandlerProps) {
+    // The form completion contract is keyed by session_id (the api-service GET
+    // /callback writes form_completed:{session_id}). Read it from context rather
+    // than prop-drilling — it is the same value config-form passes down.
+    const { sessionId } = useSession();
+
     const [status, setStatus] = useState<"idle" | "waiting" | "completed" | "error" | "timeout">(
         "idle"
     );
@@ -80,17 +85,17 @@ export default function DynamicFormHandler({
         };
     }, [cleanup]);
 
-    // Check completion function - polls GET /form/check-completion?transaction_id=X
-    // The backend resolves which form completed via the latest_form:{txn} Redis
-    // pointer and echoes form_id in the response.
+    // Check completion function - polls GET /form/check-completion?session_id=X
+    // The backend reads form_completed:{session_id} (written by the api-service
+    // GET /callback) and reports whether the form finished.
     // This is ONLY used by DYNAMIC_FORM type — does not affect HTML_FORM or any other form type.
     const checkCompletion = useCallback(async () => {
         if (hasCompletedRef.current) return;
 
         // ── Guard 1: identifiers ─────────────────────────────────────────────
-        if (!transactionId) {
-            console.warn("⚠️ [DynamicForm] Cannot poll: transactionId missing", {
-                transactionId,
+        if (!sessionId) {
+            console.warn("⚠️ [DynamicForm] Cannot poll: sessionId missing", {
+                sessionId,
             });
             return;
         }
@@ -114,40 +119,24 @@ export default function DynamicFormHandler({
         console.warn(
             `🔄 [DynamicForm] Poll #${pollCountRef.current}/${MAX_POLLS} | ` +
                 `elapsed: ${elapsedSec}s | ` +
-                `transactionId: "${transactionId}"`
+                `sessionId: "${sessionId}"`
         );
 
         try {
-            // GET /form/check-completion?transaction_id={transactionId}
-            // Backend resolves form_id via latest_form:{txn} and reads
-            // form_completed:{txn}:{form_id}.
-            // Response: { completed: boolean, form_id: string, success: boolean, message: string, timestamp: string }
-            const response = await axios.get(
-                `${import.meta.env.VITE_BACKEND_URL}/form/check-completion`,
-                {
-                    params: {
-                        transaction_id: transactionId,
-                    },
-                    timeout: 5000,
-                }
-            );
+            // GET /form/check-completion?session_id={sessionId}
+            // Backend reads form_completed:{session_id}.
+            // Response: { completed: boolean, success: boolean, message: string, timestamp: string }
+            const data = await FormService.checkCompletion(sessionId);
 
-            const { completed, success, form_id } = response.data ?? {};
+            const { completed, success } = data ?? {};
 
-            // success is a boolean from the new api-service; tolerate the legacy
-            // string form from older callback writers.
-            if (
-                completed === true &&
-                (success === true || success === "true") &&
-                !hasCompletedRef.current
-            ) {
+            if (completed === true && success === true && !hasCompletedRef.current) {
                 console.warn("✅ [DynamicForm] Form completed!", {
-                    transactionId,
-                    form_id,
+                    sessionId,
                     poll: pollCountRef.current,
                     elapsedSec,
-                    message: response.data.message,
-                    timestamp: response.data.timestamp,
+                    message: data.message,
+                    timestamp: data.timestamp,
                 });
 
                 hasCompletedRef.current = true;
@@ -168,14 +157,12 @@ export default function DynamicFormHandler({
                 // the mock service's json_path_changes requirement.
                 // TODO: replace with actual submission_id from /form/check-completion
                 // once the backend returns it from the Redis form_completed key.
-                // form_id (resolved by the backend from Redis) is passed through so
-                // the mock service's saveData config can persist it in reference_data.
                 try {
                     const submission_id = crypto.randomUUID();
                     console.warn("⚠️ [DynamicForm] Using temporary submission_id:", submission_id);
                     await submitEvent({
                         jsonPath: { submission_id },
-                        formData: { submission_id, ...(form_id ? { form_id } : {}) },
+                        formData: { submission_id },
                     });
                     setStatus("completed"); // BUG FIX: was never set — "completed" UI was dead code
                     // Parent (mapped-flow) will close the popup modal after submitEvent
@@ -191,7 +178,7 @@ export default function DynamicFormHandler({
             const err = error as { message?: string };
             console.error("Error checking completion:", err.message);
         }
-    }, [transactionId, submitEvent, cleanup]);
+    }, [sessionId, submitEvent, cleanup]);
     // NOTE: pollCountRef & pollDisplay are intentionally NOT in deps — they are refs/
     // updated imperatively. This prevents checkCompletion from being recreated on
     // every tick, which was the root cause of the stale-closure bug.
@@ -218,11 +205,7 @@ export default function DynamicFormHandler({
         console.warn("🔄 [DynamicForm] Starting polling:");
         console.warn(`   ➤ interval      : ${POLL_INTERVAL_MS}ms`);
         console.warn(`   ➤ max duration  : ${MAX_POLL_DURATION_MS / 1000}s (${MAX_POLLS} polls)`);
-        console.warn("   ➤ transactionId :", transactionId || "(empty — check flowMap)");
-        console.warn(
-            "   ➤ endpoint      :",
-            `${import.meta.env.VITE_BACKEND_URL}/form/check-completion`
-        );
+        console.warn("   ➤ sessionId     :", sessionId || "(empty — check session)");
 
         // Poll immediately first time
         checkCompletion();
@@ -231,7 +214,7 @@ export default function DynamicFormHandler({
         pollingIntervalRef.current = setInterval(() => {
             checkCompletionRef.current();
         }, POLL_INTERVAL_MS);
-    }, [transactionId, checkCompletion]);
+    }, [sessionId, checkCompletion]);
 
     // Handle start form - NO navigation/refresh
     const handleOpenForm = useCallback(
@@ -311,8 +294,8 @@ export default function DynamicFormHandler({
                 // Mark flow as active in localStorage (prevents accidental navigation)
                 localStorage.setItem("dynamic_form_flow_active", "true");
 
-                if (!transactionId) {
-                    throw new Error("Transaction ID is missing! Cannot create form URL.");
+                if (!sessionId) {
+                    throw new Error("Session ID is missing! Cannot track form completion.");
                 }
 
                 if (!formServiceUrl) {
@@ -321,15 +304,24 @@ export default function DynamicFormHandler({
                     );
                 }
 
-                // Clear any leftover completion from a previous form in this
-                // transaction so polling only reacts to THIS form's callback.
+                // Store the current workbench URL so the api-service callback can
+                // redirect the user back here and resolve the session. Sent
+                // verbatim — it already carries subscriberUrl + sessionId params.
+                // Non-fatal: completion polling still runs if this hiccups.
+                try {
+                    await FormService.saveRedirection(window.location.href);
+                } catch (saveError) {
+                    console.warn(
+                        "⚠️ [DynamicForm] Could not save redirection URL (continuing):",
+                        saveError
+                    );
+                }
+
+                // Clear any leftover completion from a previous run on this
+                // session so polling only reacts to THIS form's callback.
                 // Non-fatal: a failure here just falls back to today's behavior.
                 try {
-                    await axios.post(
-                        `${import.meta.env.VITE_BACKEND_URL}/form/reset-completion`,
-                        null,
-                        { params: { transaction_id: transactionId }, timeout: 5000 }
-                    );
+                    await FormService.resetCompletion(sessionId);
                 } catch (resetError) {
                     console.warn(
                         "⚠️ [DynamicForm] Could not reset completion state (continuing):",
@@ -370,7 +362,7 @@ export default function DynamicFormHandler({
                 cleanup();
             }
         },
-        [transactionId, formServiceUrl, startPolling, cleanup]
+        [sessionId, formServiceUrl, startPolling, cleanup]
     );
 
     // Handle reopen - NO navigation

--- a/frontend/src/services/formService.ts
+++ b/frontend/src/services/formService.ts
@@ -38,10 +38,16 @@ export class FormService {
      * POST /form/reset-completion?session_id=X
      */
     static async resetCompletion(sessionId: string): Promise<void> {
-        await apiClient.post(API_ROUTES.FORM.RESET_COMPLETION, null, {
-            params: { session_id: sessionId },
-            timeout: 5000,
-        });
+        // session_id goes as a query param; send an empty object as the body
+        // (sending null tripped the backend's JSON parsing).
+        await apiClient.post(
+            API_ROUTES.FORM.RESET_COMPLETION,
+            {},
+            {
+                params: { session_id: sessionId },
+                timeout: 5000,
+            }
+        );
     }
 
     /**


### PR DESCRIPTION


Brings main-tech to parity with main for the MANUAL_DYNAMIC_FORM / DYNAMIC_FORM feature:
- mapped-flow: BPP launch popup after first on_select (localStorage-persisted), BAP auto-proceed, and BAP-before-BPP form-step ordering.
- dynamic-form-handler: session_id-keyed completion via FormService + saveRedirection on open.
- formService: reset-completion sends an empty object body.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
