### PR TITLE
Remove BAP-before-BPP ordering wait for LAMF manual dynamic form

### DIFF
--- a/frontend/src/components/FlowShared/mapped-flow.tsx
+++ b/frontend/src/components/FlowShared/mapped-flow.tsx
@@ -208,13 +208,10 @@ export default function DisplayFlow({
             if (sessionData?.activeFlow !== flowId) return;
             submittedInputSigRef.current = sig; // proceed once per status (guards double-fire across polls)
             const submission_id = crypto.randomUUID();
-            const bapTxId = sessionData?.flowMap?.[flowId] ?? "";
-            // Raise the ordering flag once BAP's proceed resolves, so the waiting
-            // BPP form-step submit can then proceed (BAP-before-BPP at the form step).
             void handleFormSubmit({
                 jsonPath: { submission_id },
                 formData: { submission_id },
-            }).then(() => markBapProceeded(bapTxId));
+            });
             return;
         }
 
@@ -323,17 +320,6 @@ export default function DisplayFlow({
                 console.error("Transaction ID not found");
                 return;
             }
-            // LAMF ordering: the BPP *form step* must not proceed until BAP has
-            // proceeded it first. Scope strictly to the MANUAL_DYNAMIC_FORM submit
-            // (not every form in the flow), else other BPP forms would block too.
-            const isLamfManualFormSubmit =
-                isLamfRedirectionFlow &&
-                sessionData?.npType === "BPP" &&
-                activeFormConfig?.some((f) => f.type === "MANUAL_DYNAMIC_FORM");
-            if (isLamfManualFormSubmit) {
-                await waitForBapProceeded(txId);
-            }
-
             // Pass extraKey explicitly for the immediate auto-submit path (state not yet flushed);
             // popup submissions fall back to the stored key set when the form opened.
             const key = extraKey ?? activeInputExtraKey;
@@ -537,52 +523,6 @@ function isLaunchDone(markerKey: string): boolean {
     } catch {
         return false;
     }
-}
-
-// LAMF ordering (BAP must proceed the form step before BPP). BAP and BPP share the
-// transaction id and (same browser) localStorage, so BAP raises this per-run flag
-// when it proceeds and BPP waits for it. LAMF-only.
-const BAP_PROCEEDED_PREFIX = "lamf_bap_proceeded";
-
-function markBapProceeded(txId: string): void {
-    try {
-        localStorage.setItem(`${BAP_PROCEEDED_PREFIX}:${txId}`, "1");
-    } catch {
-        // localStorage unavailable — non-fatal.
-    }
-}
-
-// Resolve once BAP has proceeded (flag set), or after a safety timeout so BPP
-// never hangs forever if BAP never ran.
-function waitForBapProceeded(txId: string): Promise<void> {
-    const key = `${BAP_PROCEEDED_PREFIX}:${txId}`;
-    return new Promise((resolve) => {
-        const isSet = () => {
-            try {
-                return localStorage.getItem(key) === "1";
-            } catch {
-                return true; // can't read → don't block
-            }
-        };
-        if (isSet()) {
-            resolve();
-            return;
-        }
-        const start = Date.now();
-        const TIMEOUT_MS = 600_000;
-        const finish = () => {
-            clearInterval(iv);
-            window.removeEventListener("storage", onStorage);
-            resolve();
-        };
-        const onStorage = (e: StorageEvent) => {
-            if (e.key === key && e.newValue === "1") finish();
-        };
-        const iv = setInterval(() => {
-            if (isSet() || Date.now() - start > TIMEOUT_MS) finish();
-        }, 500);
-        window.addEventListener("storage", onStorage);
-    });
 }
 
 // Nearest actually-scrolling ancestor, or null when the window/document is the scroller.


### PR DESCRIPTION
BPP now proceeds the MANUAL_DYNAMIC_FORM step as soon as its completion callback lands, without waiting for BAP. BAP still auto-proceeds the step as before. Drops the waitForBapProceeded gate, the markBapProceeded flag bookkeeping, and the now-unused BAP_PROCEEDED_PREFIX/markBapProceeded/ waitForBapProceeded helpers.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
