### PR TITLE
Auto-proceed LAMF manual dynamic form step on BPP side too

### DIFF
--- a/frontend/src/components/FlowShared/mapped-flow.tsx
+++ b/frontend/src/components/FlowShared/mapped-flow.tsx
@@ -196,13 +196,13 @@ export default function DisplayFlow({
         submittedInputSigRef.current = undefined;
         activeInputSigRef.current = sig;
 
-        // LAMF single-redirection: the BAP side does not wait on the form callback
-        // (completion is keyed by the BPP session, which BAP can't observe). Auto-
-        // proceed past the MANUAL_DYNAMIC_FORM step immediately instead of opening
-        // the polling popup. BPP is unaffected and still drives real completion.
+        // LAMF single-redirection: both BAP and BPP auto-proceed past the
+        // MANUAL_DYNAMIC_FORM step immediately (synthetic submission_id) instead of
+        // opening the polling popup — neither side blocks on the form callback to
+        // advance the flow. Scoped strictly to the MANUAL_DYNAMIC_FORM step, so no
+        // other step/form is affected; the BPP launch popup is unchanged.
         if (
             isLamfRedirectionFlow &&
-            sessionData?.npType === "BAP" &&
             seqStep?.input?.some((f) => f.type === "MANUAL_DYNAMIC_FORM")
         ) {
             if (sessionData?.activeFlow !== flowId) return;


### PR DESCRIPTION
Drops the BAP-only guard on the MANUAL_DYNAMIC_FORM auto-proceed block so both BAP and BPP advance the step immediately with a synthetic submission_id instead of waiting on the form callback. Still scoped strictly to the LAMF flow and the MANUAL_DYNAMIC_FORM field, so DYNAMIC_FORM, HTML/static forms, and all other flows are unaffected. The BPP launch popup is unchanged.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
