### PR TITLE
Add Use Gateway toggle under Session validations

### DIFF
--- a/frontend/src/components/ui/difficulty-cards.tsx
+++ b/frontend/src/components/ui/difficulty-cards.tsx
@@ -68,11 +68,11 @@ interface DifficultyCache {
 type FilteredDifficultyCache = Partial<
     Omit<
         DifficultyCache,
-        "stopAfterFirstNack" | "sensitiveTTL" | "useGateway" | "timeValidations" | "totalDifficulty"
+        "stopAfterFirstNack" | "sensitiveTTL" | "timeValidations" | "totalDifficulty"
     >
 >;
 
-const skipItems = ["stopAfterFirstNack", "sensitiveTTL", "useGateway", "timeValidations"];
+const skipItems = ["stopAfterFirstNack", "sensitiveTTL", "timeValidations"];
 
 interface IProps {
     difficulty_cache: DifficultyCache;
@@ -95,6 +95,10 @@ const DifficultyCards = ({ difficulty_cache, sessionId }: IProps) => {
         if (newCache.sensitiveTTL) delete newCache.sensitiveTTL;
         if (newCache.stopAfterFirstNack) {
             delete newCache.stopAfterFirstNack;
+        }
+
+        if (!("useGateway" in newCache)) {
+            newCache.useGateway = true;
         }
 
         if (!("encryptionValidation" in newCache)) {


### PR DESCRIPTION
Un-hides the already-wired useGateway setting in DifficultyCards: removes it from skipItems and the FilteredDifficultyCache Omit so it renders as a toggle, and defaults it to true for sessions whose cache lacks the key. Label/tooltip, data flow, and persistence (PUT /sessions) already existed.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
