### PR TITLE
Fix build error in Use Gateway toggle

### DIFF
--- a/frontend/src/components/ui/difficulty-cards.tsx
+++ b/frontend/src/components/ui/difficulty-cards.tsx
@@ -97,10 +97,6 @@ const DifficultyCards = ({ difficulty_cache, sessionId }: IProps) => {
             delete newCache.stopAfterFirstNack;
         }
 
-        if (!("useGateway" in newCache)) {
-            newCache.useGateway = true;
-        }
-
         if (!("encryptionValidation" in newCache)) {
             newCache.encryptionValidation = false;
         }


### PR DESCRIPTION
Remove the redundant useGateway default in the normalizing effect: useGateway is a required field on DifficultyCache, so the `"useGateway" in newCache` guard narrowed to `never` under tsc -b and failed the build. The value always arrives via difficulty_cache, so the safeguard was unnecessary.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
