### PR TITLE
Add Use Gateway toggle under Session validations (main-tech)

### DIFF
--- a/frontend/src/components/ui/difficulty-cards.tsx
+++ b/frontend/src/components/ui/difficulty-cards.tsx
@@ -61,14 +61,15 @@ export interface DifficultyCache {
 export type FilteredDifficultyCache = Partial<
     Omit<
         DifficultyCache,
-        "stopAfterFirstNack" | "sensitiveTTL" | "useGateway" | "timeValidations" | "totalDifficulty"
+        "stopAfterFirstNack" | "sensitiveTTL" | "timeValidations" | "totalDifficulty"
     >
 >;
 
-const skipItems = ["stopAfterFirstNack", "sensitiveTTL", "useGateway", "timeValidations"];
+const skipItems = ["stopAfterFirstNack", "sensitiveTTL", "timeValidations"];
 
 export const SESSION_VALIDATION_DEFAULTS: FilteredDifficultyCache = {
     protocolValidations: true,
+    useGateway: true,
     headerValidaton: true,
     useGzip: false,
     encryptionValidation: false,
@@ -82,7 +83,6 @@ export function buildDifficultyState(cache: Partial<DifficultyCache>): FilteredD
         totalDifficulty: _totalDifficulty,
         sensitiveTTL: _sensitiveTTL,
         stopAfterFirstNack: _stopAfterFirstNack,
-        useGateway: _useGateway,
         timeValidations: _timeValidations,
         ...displayed
     } = merged;


### PR DESCRIPTION
Un-hide the already-defined useGateway setting in the refactored flow settings: drop it from the FilteredDifficultyCache Omit and skipItems, add it to SESSION_VALIDATION_DEFAULTS (default true), and stop stripping it in buildDifficultyState so it surfaces as a toggle. Label/tooltip and the generic onSessionDifficultyChange wiring already supported it.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
