### PR TITLE
Ride map: state buttons via normal proceed API, remove cancel, fix stuck post-confirm driver assignment

### DIFF
--- a/frontend/src/components/FlowShared/map-panel.tsx
+++ b/frontend/src/components/FlowShared/map-panel.tsx
@@ -19,7 +19,6 @@ import {
     splitPathAt,
     RIDE_STATE_ORDER,
     RIDE_STATE_BUTTON_LABEL,
-    RIDE_CANCEL_STATE,
     type LatLng,
 } from "@components/FlowShared/ride-map-utils";
 
@@ -80,6 +79,8 @@ export interface MapPanelProps {
     currentState?: string;
     /** Fired when the controller clicks a ride-state button (passes the RIDE_* code). */
     onRideState?: (state: string) => void;
+    /** The RIDE_* states currently user-clickable (all other buttons render disabled). */
+    enabledStates?: string[];
     /** Changes when the pickup/drop change — re-fits the map to the fresh locations. */
     fitKey?: string;
 }
@@ -204,6 +205,7 @@ export default function MapPanel({
     progress = 0,
     currentState,
     onRideState,
+    enabledStates,
     fitKey,
 }: MapPanelProps) {
     const pickup = useMemo(() => parseGps(pickupGps), [pickupGps]);
@@ -298,33 +300,25 @@ export default function MapPanel({
                 <div className="flex flex-wrap gap-2">
                     {RIDE_STATE_ORDER.map((state) => {
                         const active = state === currentState;
+                        const enabled = enabledStates?.includes(state) ?? false;
                         return (
                             <button
                                 key={state}
                                 type="button"
-                                onClick={() => onRideState?.(state)}
+                                disabled={!enabled}
+                                onClick={() => enabled && onRideState?.(state)}
                                 className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
                                     active
                                         ? "border-sky-500 bg-sky-100 text-sky-800 font-semibold"
-                                        : "border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100"
+                                        : enabled
+                                          ? "border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100"
+                                          : "border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed"
                                 }`}
                             >
                                 {RIDE_STATE_BUTTON_LABEL[state]}
                             </button>
                         );
                     })}
-                    {/* Terminal cancel branch — distinct red styling. */}
-                    <button
-                        type="button"
-                        onClick={() => onRideState?.(RIDE_CANCEL_STATE)}
-                        className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
-                            currentState === RIDE_CANCEL_STATE
-                                ? "border-red-500 bg-red-100 text-red-800 font-semibold"
-                                : "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
-                        }`}
-                    >
-                        {RIDE_STATE_BUTTON_LABEL[RIDE_CANCEL_STATE]}
-                    </button>
                 </div>
             )}
 

--- a/frontend/src/components/FlowShared/mapped-flow.tsx
+++ b/frontend/src/components/FlowShared/mapped-flow.tsx
@@ -129,8 +129,11 @@ export default function DisplayFlow({
 
     // --- Real-Time Ride Map Integration ------------------------------------
     // The map UI now lives in the right-panel "Application" tab (RideMapTab). Here we only need to
-    // know whether the tracking phase is active, to stop the flow engine auto-proceeding past
-    // on_confirm — the seller drives track/on_track/on_status manually from the map.
+    // know whether the tracking phase is active, to stop the flow engine auto-proceeding the ride
+    // states — the seller drives on_status/on_update manually from the map. Tracking activates only
+    // once the driver is assigned AND the initial location is shared (a track/on_track step is
+    // COMPLETE) — NOT at on_confirm, so pre-assignment steps (e.g. the unsolicited on_update driver
+    // assignment in "assign driver post on_confirm" flows) still auto-proceed normally.
     // IMPORTANT: this engine override must apply ONLY for the ride-map domain/version (TRV10 2.1.0).
     // For every other domain `trackingActive` stays false, so the normal auto-proceed behaviour of
     // track/on_track/on_status/on_update/status is fully preserved and their flows are unaffected.
@@ -195,16 +198,12 @@ export default function DisplayFlow({
         const extraStep = mappedFlow?.extraSteps?.find((s) => s.status === "INPUT-REQUIRED");
         const target = seqStep ?? extraStep;
         const conf = target?.input;
-        // Ride Map (Part A): once the ride is assigned (on_confirm complete), the tracking phase is
-        // fully manual — do NOT auto-open/auto-submit input for track/on_track/on_status/etc. The
-        // seller advances these via the map controls. EXCEPTION: `on_track_on_assign` shares the
-        // initial driver location and is seller-input-driven, so let its input form auto-open.
-        if (
-            trackingActive &&
-            isTrackingPhaseStep(target?.actionType) &&
-            target?.actionId !== "on_track_on_assign"
-        )
-            return;
+        // Ride Map (Part A): once the tracking phase is active (driver assigned + initial
+        // track/on_track complete), it is fully manual — do NOT auto-open/auto-submit input for
+        // track/on_track/on_status/etc. The seller advances these via the map controls.
+        // (Pre-tracking steps like the on_update driver assignment and on_track_on_assign are not
+        // suppressed — tracking only activates once they complete.)
+        if (trackingActive && isTrackingPhaseStep(target?.actionType)) return;
         // Extra steps must be advanced via triggerExtra (carries `trigger_extra`); use the step's
         // actionId as the trigger key. Undefined => sequence step => proceedFlow.
         const extraKey = !seqStep && extraStep ? extraStep.actionId : undefined;
@@ -257,8 +256,9 @@ export default function DisplayFlow({
     useEffect(() => {
         const latestSending = mappedFlow?.sequence.find((f) => f.status === "RESPONDING");
         const transactionId = sessionData?.flowMap[flowId];
-        // Ride Map (Part A): never auto-proceed tracking-phase steps after on_confirm — the seller
-        // drives them manually via the map.
+        // Ride Map (Part A): never auto-proceed tracking-phase steps once tracking is active
+        // (driver assigned + initial track/on_track complete) — the seller drives them manually
+        // via the map.
         if (trackingActive && isTrackingPhaseStep(latestSending?.actionType)) return;
         if (latestSending && latestSending.force_proceed && transactionId) {
             proceedFlow(sessionId, transactionId);

--- a/frontend/src/components/FlowShared/ride-map-overlays.tsx
+++ b/frontend/src/components/FlowShared/ride-map-overlays.tsx
@@ -33,11 +33,9 @@ const fmtTime = (iso?: string): string =>
 export function RideTimeline({
     currentState,
     times,
-    cancelled,
 }: {
     currentState?: string;
     times: Record<string, string>;
-    cancelled?: boolean;
 }) {
     const currentIdx = currentState
         ? RIDE_TIMELINE.indexOf(currentState as (typeof RIDE_TIMELINE)[number])
@@ -79,9 +77,6 @@ export function RideTimeline({
                     );
                 })}
             </div>
-            {cancelled && (
-                <div className="mt-1 text-xs font-semibold text-red-600">Ride cancelled</div>
-            )}
         </div>
     );
 }
@@ -182,8 +177,7 @@ export function RideInfoCard({
 
 /**
  * Read-only status panel for non-active outcomes derived from order.status + ride state:
- * driver not found, ride cancelled, cancellation in progress, or driver not assigned yet.
- * No map, no controls.
+ * driver not found or driver not assigned yet. No map, no controls.
  */
 export function RideStatusPanel({
     kind,
@@ -194,14 +188,11 @@ export function RideStatusPanel({
     title: string;
     detail?: string;
 }) {
-    const failure = kind === "DRIVER_NOT_FOUND" || kind === "CANCELLED";
-    const warn = kind === "CANCELLING";
-    const icon = failure ? "🚫" : warn ? "⚠️" : kind === "AWAITING_DRIVER" ? "⏳" : "ℹ️";
+    const failure = kind === "DRIVER_NOT_FOUND";
+    const icon = failure ? "🚫" : kind === "AWAITING_DRIVER" ? "⏳" : "ℹ️";
     const tone = failure
         ? { border: "border-red-200", bg: "bg-red-50", text: "text-red-700" }
-        : warn
-          ? { border: "border-amber-200", bg: "bg-amber-50", text: "text-amber-700" }
-          : { border: "border-sky-200", bg: "bg-sky-50", text: "text-sky-700" };
+        : { border: "border-sky-200", bg: "bg-sky-50", text: "text-sky-700" };
     return (
         <div className="p-4">
             <div
@@ -217,16 +208,14 @@ export function RideStatusPanel({
     );
 }
 
-/** ⑥ Trip summary shown when the ride is completed/cancelled. */
+/** ⑥ Trip summary shown when the ride is completed. */
 export function CompletionSummary({
-    cancelled,
     driver,
     vehicle,
     fare,
     distanceM,
     durationS,
 }: {
-    cancelled?: boolean;
     driver?: RideDriver;
     vehicle?: RideVehicle;
     fare?: RideFare;
@@ -238,17 +227,13 @@ export function CompletionSummary({
     return (
         <div className="rounded-lg border border-gray-200 bg-white p-4">
             <div className="mb-3 flex items-center gap-2">
-                <span className="text-lg">{cancelled ? "🚫" : "✅"}</span>
-                <h3
-                    className={`text-base font-semibold ${cancelled ? "text-red-700" : "text-emerald-700"}`}
-                >
-                    {cancelled ? "Ride Cancelled" : "Ride Completed"}
-                </h3>
+                <span className="text-lg">✅</span>
+                <h3 className="text-base font-semibold text-emerald-700">Ride Completed</h3>
             </div>
             <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
                 {cost && (
                     <>
-                        <dt className="text-gray-500">Fare {cancelled ? "" : "(settled)"}</dt>
+                        <dt className="text-gray-500">Fare (settled)</dt>
                         <dd className="text-right font-semibold text-gray-800">{cost}</dd>
                     </>
                 )}
@@ -279,12 +264,8 @@ export function CompletionSummary({
                         <dd className="text-right text-gray-800">{veh}</dd>
                     </>
                 )}
-                {!cancelled && (
-                    <>
-                        <dt className="text-gray-500">Order status</dt>
-                        <dd className="text-right font-medium text-emerald-700">COMPLETE</dd>
-                    </>
-                )}
+                <dt className="text-gray-500">Order status</dt>
+                <dd className="text-right font-medium text-emerald-700">COMPLETE</dd>
             </dl>
         </div>
     );

--- a/frontend/src/components/FlowShared/ride-map-tab.tsx
+++ b/frontend/src/components/FlowShared/ride-map-tab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { FlowMap } from "@/types/flow-state-type";
 import { useSession } from "@context/context";
-import { triggerExtra, getMappedFlow, getRoute } from "@utils/request-utils";
+import { proceedFlow, triggerExtra, getMappedFlow, getRoute } from "@utils/request-utils";
 import MapPanel from "@components/FlowShared/map-panel";
 import {
     deriveRideMapData,
@@ -10,6 +10,8 @@ import {
     currentRideState,
     isRideEnded,
     nextAutoState,
+    nextPendingTrackingActionId,
+    computeEnabledRideStates,
     phaseToLabel,
     pointAlong,
     progressAlong,
@@ -46,6 +48,8 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     const [localDriverGps, setLocalDriverGps] = useState<string | undefined>(undefined);
     const [localPhase, setLocalPhase] = useState<string | undefined>(undefined);
     const [trackingReset, setTrackingReset] = useState(false);
+    // True while a ride-state proceed is in flight — locks all state buttons (no double-fire).
+    const [sendingState, setSendingState] = useState(false);
     const autoStateFiredRef = useRef<Set<string>>(new Set());
     const payloadCacheRef = useRef<Map<string, unknown>>(new Map());
 
@@ -107,20 +111,27 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     }, [mappedFlow]);
 
     // `code` is the RIDE_* fulfillment-state code (the button values are the codes themselves).
-    // Returns true only when the on_status/on_update was actually dispatched to the buyer — callers
-    // gate the driver animation on this so movement never starts before the buyer is updated.
+    // Each state change advances the flow through the NORMAL proceed API: the next pending
+    // tracking-phase sequence step (on_status/on_update) is dispatched by passing its actionId as
+    // `inputs.id` — no trigger_extra. Returns true only when the step was actually dispatched to
+    // the buyer — callers gate the driver animation on this so movement never starts before the
+    // buyer is updated.
     const sendRideState = async (code: string): Promise<boolean> => {
         if (!transactionId || !sessionData) return false;
+        const actionId = nextPendingTrackingActionId(mappedFlow);
+        if (!actionId) {
+            toast.error("No pending ride-state step to proceed");
+            return false;
+        }
         const prevPhase = localPhase;
         setLocalPhase(code);
-        // RIDE_ENDED is delivered via on_update (per the contract); all other states via on_status.
-        const extraKey = code === "RIDE_ENDED" ? "on_update_state" : "on_status_state";
+        setSendingState(true);
         try {
-            const res = await triggerExtra(sessionId, transactionId, extraKey, { code });
+            const res = await proceedFlow(sessionId, transactionId, undefined, { id: actionId });
             if (res?.success === false) {
                 setLocalPhase(prevPhase);
                 toast.error(res.message || "Ride state not dispatched");
-                console.warn("on_status_state trigger rejected:", res.message);
+                console.warn("ride-state proceed rejected:", res.message);
                 return false;
             }
             return true;
@@ -129,6 +140,8 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
             toast.error("Failed to send ride state");
             console.error(e);
             return false;
+        } finally {
+            setSendingState(false);
         }
     };
 
@@ -231,14 +244,14 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
         if (first) sendOnTrack(first); // initial location immediately
     };
 
-    // End the ride: on_update (RIDE_ENDED) then ONE unsolicited on_status marking the order
-    // completed (order.status = COMPLETE, state = RIDE_COMPLETED). Fires the completed step once.
+    // End the ride: proceed the RIDE_ENDED step, then the completion step (order.status =
+    // COMPLETE, state = RIDE_COMPLETED). Fires the completed step once.
     const completedFiredRef = useRef(false);
     const endRide = async () => {
-        await sendRideState("RIDE_ENDED"); // on_update
+        await sendRideState("RIDE_ENDED");
         if (!completedFiredRef.current) {
             completedFiredRef.current = true;
-            await sendRideState("RIDE_COMPLETED"); // on_status → order.status COMPLETE
+            await sendRideState("RIDE_COMPLETED");
         }
         autoRunRef.current = false;
         setAutoRunActive(false);
@@ -275,7 +288,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
             endRide();
             return;
         }
-        // Arrived / Completed / Cancel — stop any movement and send the state.
+        // Arrived / Completed — stop any movement and send the state.
         stopAnimation();
         sendRideState(code);
     };
@@ -394,6 +407,9 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
         };
     }, [rideMap.pickupGps, rideMap.dropGps]);
 
+    // Only Enroute → Started are user-clickable, in sequence, once each (locked while sending).
+    const enabledStates = computeEnabledRideStates(phase, sendingState);
+
     // Driver progress along the active segment (drives two-tone route + ETA panel).
     const progress = activeRoute
         ? progressAlong(activeRoute.geometry, parseGps(driverGpsForMap))
@@ -408,8 +424,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     }
 
     // State-based outcome (driven purely by order.status + ride state + error). Non-active terminal
-    // / failure outcomes get a read-only status panel — no map, no ride controls. The seller's live
-    // local phase takes precedence so map-driven cancels reflect immediately.
+    // / failure outcomes get a read-only status panel — no map, no ride controls.
     const display = deriveRideDisplay({
         phase,
         orderStatus: rideMap.orderStatus,
@@ -418,10 +433,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     if (
         rideMap.isTracking &&
         !trackingReset &&
-        (display.kind === "DRIVER_NOT_FOUND" ||
-            display.kind === "AWAITING_DRIVER" ||
-            display.kind === "CANCELLED" ||
-            display.kind === "CANCELLING")
+        (display.kind === "DRIVER_NOT_FOUND" || display.kind === "AWAITING_DRIVER")
     ) {
         return (
             <RideStatusPanel kind={display.kind} title={display.title} detail={display.detail} />
@@ -458,7 +470,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     }
 
     const showEta = !!activeRoute && (phase === "RIDE_ENROUTE_PICKUP" || phase === "RIDE_STARTED");
-    const finished = phase === "RIDE_COMPLETED" || phase === "RIDE_CANCELLED";
+    const finished = phase === "RIDE_COMPLETED";
 
     return (
         <div className="p-2 space-y-2">
@@ -506,11 +518,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
             </div>
 
             {/* ① Status timeline */}
-            <RideTimeline
-                currentState={phase}
-                times={phaseTimes}
-                cancelled={phase === "RIDE_CANCELLED"}
-            />
+            <RideTimeline currentState={phase} times={phaseTimes} />
 
             {/* ②/⑤ Driver / vehicle / fare card */}
             <RideInfoCard driver={rideMap.driver} vehicle={rideMap.vehicle} fare={rideMap.fare} />
@@ -518,7 +526,6 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
             {/* ⑥ Completion summary (replaces ETA once the ride finishes) */}
             {finished && (
                 <CompletionSummary
-                    cancelled={phase === "RIDE_CANCELLED"}
                     driver={rideMap.driver}
                     vehicle={rideMap.vehicle}
                     fare={rideMap.fare}
@@ -552,6 +559,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
                 onReset={handleResetTracking}
                 currentState={phase}
                 onRideState={handleRideState}
+                enabledStates={enabledStates}
             />
         </div>
     );

--- a/frontend/src/components/FlowShared/ride-map-utils.ts
+++ b/frontend/src/components/FlowShared/ride-map-utils.ts
@@ -56,8 +56,6 @@ export const isRideMapEnabled = (domain?: string, version?: string): boolean =>
 export type RideDisplayKind =
     | "DRIVER_NOT_FOUND"
     | "AWAITING_DRIVER"
-    | "CANCELLED"
-    | "CANCELLING"
     | "COMPLETED"
     | "ACTIVE"
     | "AWAITING";
@@ -108,32 +106,12 @@ export function deriveRideDisplay(input: {
         };
     }
 
-    // 2) Cancelled (hard) — ride state or order status.
-    if (phase === "RIDE_CANCELLED" || status === "CANCELLED") {
-        return {
-            kind: "CANCELLED",
-            title: "Ride cancelled",
-            detail: "This ride was cancelled.",
-            showsControls: false,
-        };
-    }
-
-    // 3) Soft cancel requested (not yet final).
-    if (status === "SOFT_CANCEL") {
-        return {
-            kind: "CANCELLING",
-            title: "Cancellation in progress",
-            detail: "A cancellation has been requested for this ride.",
-            showsControls: false,
-        };
-    }
-
-    // 4) Completed — keyed off ride state (order.status stays ACTIVE) or an explicit COMPLETE.
+    // 2) Completed — keyed off ride state (order.status stays ACTIVE) or an explicit COMPLETE.
     if (phase === "RIDE_COMPLETED" || status === "COMPLETE" || status === "COMPLETED") {
         return { kind: "COMPLETED", title: "Ride completed", showsControls: false };
     }
 
-    // 5) Confirmed but driver not yet assigned (assignment happens later via on_update).
+    // 3) Confirmed but driver not yet assigned (assignment happens later via on_update).
     if (phase === "RIDE_CONFIRMED") {
         return {
             kind: "AWAITING_DRIVER",
@@ -143,12 +121,12 @@ export function deriveRideDisplay(input: {
         };
     }
 
-    // 6) Active ride (SOFT_UPDATE/UPDATED are transient → still active).
+    // 4) Active ride (SOFT_UPDATE/UPDATED are transient → still active).
     if (phase && RIDE_ACTIVE_STATES.has(phase)) {
         return { kind: "ACTIVE", title: "Ride in progress", showsControls: true };
     }
 
-    // 7) Nothing assigned yet (pre-confirm / awaiting).
+    // 5) Nothing assigned yet (pre-confirm / awaiting).
     return { kind: "AWAITING", title: "Awaiting ride", showsControls: false };
 }
 
@@ -159,14 +137,13 @@ const RIDE_PHASE_LABELS: Record<string, string> = {
     RIDE_STARTED: "Ride started",
     RIDE_ENDED: "Ride ended",
     RIDE_COMPLETED: "Ride completed (settled)",
-    RIDE_CANCELLED: "Cancelled",
 };
 
 export const phaseToLabel = (phase?: string): string | undefined =>
     phase ? (RIDE_PHASE_LABELS[phase] ?? phase) : undefined;
 
 export const isRideEnded = (phase?: string): boolean =>
-    phase === "RIDE_ENDED" || phase === "RIDE_COMPLETED" || phase === "RIDE_CANCELLED";
+    phase === "RIDE_ENDED" || phase === "RIDE_COMPLETED";
 
 // Ordered forward ride states the seller can advance through (RIDE_ASSIGNED is set by on_confirm).
 export const RIDE_STATE_ORDER = [
@@ -178,9 +155,6 @@ export const RIDE_STATE_ORDER = [
 ] as const;
 export type RideState = (typeof RIDE_STATE_ORDER)[number];
 
-// Terminal cancel branch — rendered as a separate control, not part of the forward progression.
-export const RIDE_CANCEL_STATE = "RIDE_CANCELLED";
-
 // Short labels for the state buttons.
 export const RIDE_STATE_BUTTON_LABEL: Record<string, string> = {
     RIDE_ENROUTE_PICKUP: "Enroute",
@@ -188,7 +162,6 @@ export const RIDE_STATE_BUTTON_LABEL: Record<string, string> = {
     RIDE_STARTED: "Started",
     RIDE_ENDED: "Ended",
     RIDE_COMPLETED: "Completed",
-    RIDE_CANCELLED: "Cancel",
 };
 
 // --- geometry helpers -------------------------------------------------------
@@ -236,6 +209,23 @@ export const RIDE_TIMELINE = [
     "RIDE_ENDED",
     "RIDE_COMPLETED",
 ] as const;
+/**
+ * Which state buttons the user may click right now. Only Enroute and Started are ever
+ * user-clickable, strictly in sequence and once each (success advances the phase, which
+ * permanently consumes the button); everything else is auto-fired. While a send is in
+ * flight, nothing is clickable.
+ */
+export function computeEnabledRideStates(phase: string | undefined, sending: boolean): string[] {
+    if (sending) return [];
+    // Unknown/pre-timeline phase = tracking just started → Enroute is the first available action.
+    const idx = phase ? RIDE_TIMELINE.indexOf(phase as (typeof RIDE_TIMELINE)[number]) : -1;
+    const enrouteIdx = RIDE_TIMELINE.indexOf("RIDE_ENROUTE_PICKUP");
+    const startedIdx = RIDE_TIMELINE.indexOf("RIDE_STARTED");
+    if (idx < enrouteIdx) return ["RIDE_ENROUTE_PICKUP"];
+    if (idx < startedIdx) return ["RIDE_STARTED"];
+    return [];
+}
+
 export const RIDE_TIMELINE_LABEL: Record<string, string> = {
     RIDE_ASSIGNED: "Assigned",
     RIDE_ENROUTE_PICKUP: "Enroute",
@@ -354,6 +344,20 @@ export function nextPendingRideState(mappedFlow: FlowMap): RideState | undefined
 }
 
 /**
+ * The actionId of the next not-yet-complete tracking-phase step (on_status/on_update) in the
+ * sequence — passed as `inputs.id` to the normal proceed API so the flow engine dispatches that
+ * step (manual steps require `inputs.id === actionId`).
+ */
+export function nextPendingTrackingActionId(mappedFlow: FlowMap): string | undefined {
+    const step = (mappedFlow.sequence ?? []).find(
+        (s) =>
+            (s.actionType === "on_status" || s.actionType === "on_update") &&
+            s.status !== "COMPLETE"
+    );
+    return step?.actionId;
+}
+
+/**
  * The current ride state — derived DETERMINISTICALLY from the latest COMPLETE on_status/on_confirm
  * step, so the map always mirrors what the flow has actually sent (no payload guessing).
  */
@@ -373,8 +377,12 @@ export const isTrackingPhaseStep = (actionType?: string): boolean =>
     !!actionType && TRACKING_PHASE_TYPES.has(actionType);
 
 /**
- * Synchronous "is the ride confirmed?" check — the ride map / tracking phase is active once a
- * confirm OR on_confirm is COMPLETE (from either side's recorded view).
+ * Synchronous "is the manual tracking phase active?" check. Tracking starts only once the driver
+ * is assigned AND the driver's initial location has been shared — i.e. a track/on_track step
+ * (e.g. on_track_on_assign) is COMPLETE (from either side's recorded view). NOT at on_confirm:
+ * pre-assignment steps (the unsolicited on_update driver assignment, the initial on_track) must
+ * keep the flow engine's normal auto-proceed behavior or flows that assign the driver post-confirm
+ * get stuck.
  */
 export function isTrackingActive(mappedFlow: FlowMap): boolean {
     const lists = [
@@ -385,8 +393,7 @@ export function isTrackingActive(mappedFlow: FlowMap): boolean {
     return lists.some((l) =>
         l.some(
             (s) =>
-                (s.actionType === "on_confirm" || s.actionType === "confirm") &&
-                s.status === "COMPLETE"
+                (s.actionType === "on_track" || s.actionType === "track") && s.status === "COMPLETE"
         )
     );
 }


### PR DESCRIPTION
- Ride-state buttons now advance the flow through the normal proceed API, passing the next pending tracking step's actionId as inputs.id (no trigger_extra); on_track_driver_move stays the only extra-trigger call (2s cadence during movement + drag).
- Only Enroute and Started are user-clickable, strictly in sequence and once each; all buttons lock while a send is in flight.
- Remove the Cancel button and all RIDE_CANCELLED handling.
- Fix flows that assign the driver post on_confirm (on_update_ride) getting stuck: tracking now activates only once a track/on_track step is COMPLETE (driver assigned + initial location shared), not at on_confirm, so the pre-assignment on_update auto-proceeds normally.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
