### PR TITLE
feat(trv10): remove item quantity input from select form

### DIFF
--- a/frontend/src/components/Forms/custom-forms/trv10-select-form.tsx
+++ b/frontend/src/components/Forms/custom-forms/trv10-select-form.tsx
@@ -196,15 +196,6 @@ export default function TRV10SelectForm({ submitEvent }: ITRV10SelectFormProps) 
                                 />
                             )}
 
-                            <TextField
-                                control={control}
-                                name={`items.${index}.count`}
-                                label="Quantity"
-                                type="number"
-                                min={1}
-                                required
-                            />
-
                             {selectedExtracted && selectedExtracted.addOns.length > 0 && (
                                 <div className="space-y-2">
                                     <ComboBoxControl


### PR DESCRIPTION
Drop the per-item Quantity field from TRV10SelectForm — the user now only picks the item and add-ons. Each item still submits count: 1 internally (payload shape unchanged); the select generate never reads count/quantity. Add-on quantity controls are unaffected.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
