### PR TITLE
Main tech

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.879.0",
         "@aws-sdk/s3-request-presigner": "^3.879.0",
         "@ondc/automation-logger": "^1.1.0",
+        "@ondc/ondc-automation-cache-lib": "^2.1.0",
         "@types/axios": "^0.14.4",
         "@types/multer": "^2.0.0",
         "axios": "^1.10.0",
@@ -27,7 +28,6 @@
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
         "multer": "^2.0.2",
-        "ondc-automation-cache-lib": "^2.0.0",
         "redis": "^4.7.0",
         "uuid": "^11.0.3",
         "winston": "^3.17.0"
@@ -1480,6 +1480,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/@ondc/ondc-automation-cache-lib": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ondc/ondc-automation-cache-lib/-/ondc-automation-cache-lib-2.1.1.tgz",
+      "integrity": "sha512-uxSq5XdbxsyXuEZlUcRAC3sugKkFYAOWY8WIXGwDv+AW0V/JLQ/Cbhv8Ls2T82qHCc1/YmklKhqejsEQN/Hhgg==",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "ioredis": "^5.4.1"
+      }
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -6541,16 +6551,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/ondc-automation-cache-lib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ondc-automation-cache-lib/-/ondc-automation-cache-lib-2.0.0.tgz",
-      "integrity": "sha512-d/8/pdXDOOx8Bnp/zUoIo2VgoPPj35a0HjVGLLMR8bFTdJWNlZkc6aOL54Sk6PFN/zFI6bEBQtcR/BkogkAmaQ==",
-      "license": "ISC",
-      "dependencies": {
-        "dotenv": "^16.4.5",
-        "ioredis": "^5.4.1"
       }
     },
     "node_modules/one-time": {

--- a/backend/src/routes/flowRoutes.ts
+++ b/backend/src/routes/flowRoutes.ts
@@ -59,9 +59,36 @@ router.post(
 );
 router.post("/external-form", async (req, res) => {
 	try {
-		const { link, data } = req.body;
-		const exRes = await axios.post(link, data);
-		logger.info("Submission response", exRes);
+		const { link, data, enctype } = req.body as {
+			link: string;
+			data: unknown;
+			enctype?: string;
+		};
+		const ct = (enctype || "").toLowerCase();
+
+		let forwardBody: unknown;
+		const headers: Record<string, string> = {};
+
+		if (ct.includes("multipart/form-data")) {
+			const fd = new FormData();
+			const record = (data ?? {}) as Record<string, string | string[]>;
+			for (const [key, value] of Object.entries(record)) {
+				if (Array.isArray(value)) {
+					for (const v of value) fd.append(key, v);
+				} else {
+					fd.append(key, String(value));
+				}
+			}
+			forwardBody = fd;
+		} else if (ct.includes("application/x-www-form-urlencoded")) {
+			forwardBody = data;
+			headers["Content-Type"] = "application/x-www-form-urlencoded";
+		} else {
+			forwardBody = data;
+		}
+
+		const exRes = await axios.post(link, forwardBody, { headers });
+		logger.info("Submission response", { status: exRes.status, url: link });
 		res.status(exRes.status).send(exRes.data);
 	} catch (e) {
 		logger.error("GATE WAY ERROR", {}, e);

--- a/frontend/src/components/Forms/custom-forms/protocol-html-form-multi.tsx
+++ b/frontend/src/components/Forms/custom-forms/protocol-html-form-multi.tsx
@@ -186,6 +186,7 @@ export default function ProtocolHTMLFormMulti({
             const submitData = await htmlFormSubmitMutation({
                 link: parsed.action || window.location.href,
                 data: arrayPayload,
+                enctype: parsed.enctype ?? undefined,
             }).unwrap();
             const res = { data: submitData, headers: undefined } as unknown as AxiosResponse<
                 unknown,

--- a/frontend/src/components/Forms/custom-forms/protocol-html-form.tsx
+++ b/frontend/src/components/Forms/custom-forms/protocol-html-form.tsx
@@ -427,6 +427,7 @@ export default function ProtocolHTMLForm({
                 const submitData = await htmlFormSubmitMutation({
                     link: parsed.action || window.location.href,
                     data: payload,
+                    enctype: parsed.enctype ?? undefined,
                 }).unwrap();
                 res = { data: submitData, headers: undefined } as unknown as AxiosResponse<
                     unknown,
@@ -467,6 +468,7 @@ export default function ProtocolHTMLForm({
                 const submitData = await htmlFormSubmitMutation({
                     link: parsed.action || window.location.href,
                     data: params.toString(),
+                    enctype: "application/x-www-form-urlencoded",
                 }).unwrap();
                 res = { data: submitData, headers: undefined } as unknown as AxiosResponse<
                     unknown,

--- a/frontend/src/store/api/main/endpoints/flow/flow.api.ts
+++ b/frontend/src/store/api/main/endpoints/flow/flow.api.ts
@@ -163,11 +163,14 @@ export const flowApi = mainApi.injectEndpoints({
                 }
             },
         }),
-        htmlFormSubmit: builder.mutation<unknown, { link: string; data: unknown }>({
-            query: ({ link, data }) => ({
+        htmlFormSubmit: builder.mutation<
+            unknown,
+            { link: string; data: unknown; enctype?: string }
+        >({
+            query: ({ link, data, enctype }) => ({
                 url: API_ROUTES.FLOW.EXTERNAL_FORM,
                 method: "POST",
-                data: { link, data },
+                data: { link, data, enctype },
             }),
         }),
         updateCustomFlow: builder.mutation<unknown, { sessionId: string; flow: unknown }>({


### PR DESCRIPTION
Dev to prod MR covering the NP issue fix for external lender form submissions were failing with a 500 error because the workbench was not honouring the ONDC protocol requirement of sending forms with Content-Type: multipart/form-data.

The backend proxy now correctly forwards form data in the format the ONDC spec mandates, ensuring the lender's server can parse and process the submission.