### PR TITLE
fix Clear Flow resuming from previous progress

### DIFF
--- a/backend/src/services/sessionService.ts
+++ b/backend/src/services/sessionService.ts
@@ -187,6 +187,23 @@ export const updateSessionService = async (
   }
 };
 
+const removeFlowFromSession = (
+  session: SessionCache,
+  flowId: string,
+): string | undefined => {
+  const transactionId = session.flowMap[flowId];
+  if (transactionId) {
+    const index = session.transactionIds.indexOf(transactionId);
+    if (index > -1) {
+      session.transactionIds.splice(index, 1);
+    }
+  }
+  // delete so JSON.stringify omits the key (undefined would also omit, but
+  // leave no ambiguity for concurrent readers)
+  delete session.flowMap[flowId];
+  return transactionId;
+};
+
 export const clearFlowService = async (
   sessionId: string,
   flowId: string,
@@ -200,19 +217,45 @@ export const clearFlowService = async (
 
     const session: SessionCache = JSON.parse(sessionData);
     logger.debug(JSON.stringify(session));
-    const transactionId = session.flowMap[flowId];
-    if (transactionId) {
-      const index = session.transactionIds.indexOf(transactionId);
-      if (index > -1) {
-        session.transactionIds.splice(index, 1);
-      }
-    }
-    session.flowMap[flowId] = undefined;
+    const transactionId = removeFlowFromSession(session, flowId);
+
     await RedisService.setKey(
       sessionId,
       JSON.stringify(session),
       SESSION_EXPIRY,
     );
+
+    // Best-effort: drop cached transaction so a stale flowMap cannot resume it
+    if (transactionId) {
+      try {
+        await RedisService.deleteKey(transactionId);
+      } catch (deleteError: any) {
+        logger.warning(
+          `Failed to delete transaction cache for ${transactionId}`,
+          loggerMeta,
+          deleteError,
+        );
+      }
+    }
+
+    // Concurrent session updates (e.g. stop writing activeFlow) can overwrite
+    // this clear via read-modify-write. Re-check and re-apply once if needed.
+    const verifyRaw = await RedisService.getKey(sessionId);
+    if (verifyRaw) {
+      const verified: SessionCache = JSON.parse(verifyRaw);
+      if (verified.flowMap?.[flowId]) {
+        logger.warning(
+          `Flow ${flowId} reappeared after clear; re-applying clear`,
+          loggerMeta,
+        );
+        removeFlowFromSession(verified, flowId);
+        await RedisService.setKey(
+          sessionId,
+          JSON.stringify(verified),
+          SESSION_EXPIRY,
+        );
+      }
+    }
   } catch (e: any) {
     logger.error("Error clearing flow", loggerMeta, e);
     throw new Error("Error clearing flow");

--- a/backend/src/services/sessionService.ts
+++ b/backend/src/services/sessionService.ts
@@ -187,23 +187,6 @@ export const updateSessionService = async (
   }
 };
 
-const removeFlowFromSession = (
-  session: SessionCache,
-  flowId: string,
-): string | undefined => {
-  const transactionId = session.flowMap[flowId];
-  if (transactionId) {
-    const index = session.transactionIds.indexOf(transactionId);
-    if (index > -1) {
-      session.transactionIds.splice(index, 1);
-    }
-  }
-  // delete so JSON.stringify omits the key (undefined would also omit, but
-  // leave no ambiguity for concurrent readers)
-  delete session.flowMap[flowId];
-  return transactionId;
-};
-
 export const clearFlowService = async (
   sessionId: string,
   flowId: string,
@@ -217,45 +200,19 @@ export const clearFlowService = async (
 
     const session: SessionCache = JSON.parse(sessionData);
     logger.debug(JSON.stringify(session));
-    const transactionId = removeFlowFromSession(session, flowId);
-
+    const transactionId = session.flowMap[flowId];
+    if (transactionId) {
+      const index = session.transactionIds.indexOf(transactionId);
+      if (index > -1) {
+        session.transactionIds.splice(index, 1);
+      }
+    }
+    session.flowMap[flowId] = undefined;
     await RedisService.setKey(
       sessionId,
       JSON.stringify(session),
       SESSION_EXPIRY,
     );
-
-    // Best-effort: drop cached transaction so a stale flowMap cannot resume it
-    if (transactionId) {
-      try {
-        await RedisService.deleteKey(transactionId);
-      } catch (deleteError: any) {
-        logger.warning(
-          `Failed to delete transaction cache for ${transactionId}`,
-          loggerMeta,
-          deleteError,
-        );
-      }
-    }
-
-    // Concurrent session updates (e.g. stop writing activeFlow) can overwrite
-    // this clear via read-modify-write. Re-check and re-apply once if needed.
-    const verifyRaw = await RedisService.getKey(sessionId);
-    if (verifyRaw) {
-      const verified: SessionCache = JSON.parse(verifyRaw);
-      if (verified.flowMap?.[flowId]) {
-        logger.warning(
-          `Flow ${flowId} reappeared after clear; re-applying clear`,
-          loggerMeta,
-        );
-        removeFlowFromSession(verified, flowId);
-        await RedisService.setKey(
-          sessionId,
-          JSON.stringify(verified),
-          SESSION_EXPIRY,
-        );
-      }
-    }
   } catch (e: any) {
     logger.error("Error clearing flow", loggerMeta, e);
     throw new Error("Error clearing flow");

--- a/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
@@ -10,6 +10,7 @@ import {
     useDeleteExpectationMutation,
     useLazyGetCompletePayloadQuery,
     useLazyGetMappedFlowQuery,
+    useLazyGetSessionByIdQuery,
     useNewFlowMutation,
     useProceedFlowMutation,
     usePutCacheDataMutation,
@@ -84,6 +85,7 @@ export function FlowRunAccordion({
     const [deleteExpectation] = useDeleteExpectationMutation();
     const [triggerGetCompletePayload] = useLazyGetCompletePayloadQuery();
     const [triggerGetMappedFlow] = useLazyGetMappedFlowQuery();
+    const [triggerGetSessionById] = useLazyGetSessionByIdQuery();
     const [newFlow] = useNewFlowMutation();
     const [proceedFlow] = useProceedFlowMutation();
     const [putCacheData] = usePutCacheDataMutation();
@@ -215,14 +217,27 @@ export function FlowRunAccordion({
         setIsBusy(false);
 
         try {
-            const canStart = await canStartFlow(sessionCache, mappedFlow);
+            // Always decide resume vs new from the latest server session so a
+            // just-cleared flow never resumes from a stale React/Redux cache.
+            let latestSession = sessionCache;
+            try {
+                const refreshed = await triggerGetSessionById({ sessionId }).unwrap();
+                latestSession = refreshed as SessionCache;
+            } catch (refreshError) {
+                console.error(
+                    "Failed to refresh session before start; using cached session",
+                    refreshError
+                );
+            }
+
+            const canStart = await canStartFlow(latestSession, mappedFlow);
             if (gen !== lifecycleGenRef.current) return;
             if (!canStart) {
                 revertActiveFlow(previousActive);
                 return;
             }
 
-            const given = sessionCache.flowMap[flow.id];
+            const given = latestSession.flowMap?.[flow.id];
             if (given) {
                 toast.info("Resuming the flow!");
                 await proceedFlow({ sessionId, transactionId: given }).unwrap();
@@ -283,29 +298,31 @@ export function FlowRunAccordion({
         applyOptimisticActiveFlow(null);
         setIsOpen(false);
         onFlowStop();
-        setIsBusy(false);
 
         try {
             trackEvent({
                 category: "SCENARIO_TESTING-FLOWS",
                 action: `Stopped a flow: ${flow.id}`,
             });
-            // Fire deleteExpectation without blocking the UI; cache write is awaited so
-            // the lifecycle lock covers the window where polls could still see the old activeFlow.
+            // Persist stop before enabling Clear so a concurrent clearFlow write
+            // cannot be overwritten by a late putCacheData RMW of the session.
             void deleteExpectation({ sessionId, subscriberUrl: subUrl });
             await putCacheData({ data: { activeFlow: "NONE" }, sessionId });
         } catch (err) {
             console.error(err);
+            toast.error("Error while stopping flow");
         } finally {
             if (gen === lifecycleGenRef.current) {
                 endActiveFlowLifecycle();
             }
+            setIsBusy(false);
         }
     };
 
     const handleClearClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
-        if (isBusy) return;
+        // Block Clear while Stop/Start is still persisting session state.
+        if (isBusy || lifecycleInFlight) return;
         setIsBusy(true);
         try {
             trackEvent({
@@ -320,8 +337,10 @@ export function FlowRunAccordion({
                 ),
                 missedSteps: [],
             });
-            onFlowClear();
-            void clearFlowData({ sessionId, flowId: flow.id });
+            // Optimistically drop the flow from the parent session cache so Start
+            // cannot resume from a stale flowMap.
+            onFlowClear(flow.id);
+            await clearFlowData({ sessionId, flowId: flow.id });
         } finally {
             setIsBusy(false);
         }

--- a/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
@@ -49,6 +49,8 @@ export function FlowRunAccordion({
     onFlowStop,
     onFlowClear,
     onFlowClearSettled,
+    shouldForceFreshStart,
+    onFreshStartConsumed,
 }: IFlowRunAccordionProps) {
     const [inputPopUp, setInputPopUp] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
@@ -221,8 +223,8 @@ export function FlowRunAccordion({
         setIsBusy(false);
 
         try {
-            // Always decide resume vs new from the latest server session so a
-            // just-cleared flow never resumes from a stale React/Redux cache.
+            // Refresh for canStart / server truth, but Clear intent wins over a stale
+            // server flowMap (late GETs can reintroduce the mapping after Clear).
             let latestSession = sessionCache;
             try {
                 const refreshed = await triggerGetSessionById({ sessionId }).unwrap();
@@ -241,11 +243,22 @@ export function FlowRunAccordion({
                 return;
             }
 
-            const given = latestSession.flowMap?.[flow.id];
-            if (given) {
+            const forceFresh = shouldForceFreshStart(flow.id) || !sessionCache.flowMap?.[flow.id];
+            const serverTx = latestSession.flowMap?.[flow.id];
+            const localTx = sessionCache.flowMap?.[flow.id];
+
+            if (!forceFresh && (serverTx || localTx)) {
                 toast.info("Resuming the flow!");
-                await proceedFlow({ sessionId, transactionId: given }).unwrap();
+                await proceedFlow({
+                    sessionId,
+                    transactionId: (serverTx || localTx) as string,
+                }).unwrap();
             } else {
+                // Server may still carry the old mapping after Clear — clear again so
+                // the new transaction is the only one, then start fresh (NACK vs uncleared peer).
+                if (serverTx) {
+                    await clearFlowData({ sessionId, flowId: flow.id });
+                }
                 const txId = uuidv4();
                 const result = await newFlow({ sessionId, flowId: flow.id, transactionId: txId });
                 const data = result.data;
@@ -255,6 +268,7 @@ export function FlowRunAccordion({
                     setActiveFormTitle(flow.title ?? flow.id);
                     setInputPopUp(true);
                 }
+                onFreshStartConsumed(flow.id);
             }
             if (gen !== lifecycleGenRef.current) return;
             await putCacheData({ data: { activeFlow: flow.id }, sessionId });

--- a/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/FlowRunAccordion/index.tsx
@@ -48,6 +48,7 @@ export function FlowRunAccordion({
     subUrl,
     onFlowStop,
     onFlowClear,
+    onFlowClearSettled,
 }: IFlowRunAccordionProps) {
     const [inputPopUp, setInputPopUp] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
@@ -70,6 +71,7 @@ export function FlowRunAccordion({
     const activeFlowRef = useRef(activeFlow);
     activeFlowRef.current = activeFlow;
     const lifecycleGenRef = useRef(0);
+    const isClearingRef = useRef(false);
 
     const {
         isFlowFormDialogOpen,
@@ -150,6 +152,8 @@ export function FlowRunAccordion({
     // Refresh mapped-flow for flows that already have a transaction — do not touch activeFlow here.
     const flowMapEntry = sessionCache?.flowMap?.[flow.id];
     useEffect(() => {
+        // Skip while Clear is resetting — a stale session poll must not rehydrate progress.
+        if (isClearingRef.current) return;
         if (flowMapEntry && sessionCache) {
             void getCurrentState(sessionCache);
         }
@@ -322,8 +326,9 @@ export function FlowRunAccordion({
     const handleClearClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
         // Block Clear while Stop/Start is still persisting session state.
-        if (isBusy || lifecycleInFlight) return;
+        if (isBusy || lifecycleInFlight || isClearingRef.current) return;
         setIsBusy(true);
+        isClearingRef.current = true;
         try {
             trackEvent({
                 category: "SCENARIO_TESTING-FLOWS",
@@ -338,10 +343,12 @@ export function FlowRunAccordion({
                 missedSteps: [],
             });
             // Optimistically drop the flow from the parent session cache so Start
-            // cannot resume from a stale flowMap.
+            // cannot resume from a stale flowMap and progress cannot rehydrate.
             onFlowClear(flow.id);
             await clearFlowData({ sessionId, flowId: flow.id });
+            onFlowClearSettled(flow.id);
         } finally {
+            isClearingRef.current = false;
             setIsBusy(false);
         }
     };

--- a/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
@@ -89,9 +89,14 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
 
     const activeFlowRef = useRef<string | null>(activeFlowId);
     const sessionDataPrimedRef = useRef(false);
+    // Bumped on Clear so in-flight session GETs from before Clear cannot restore flowMap.
+    const sessionFetchGenRef = useRef(0);
     // Flows cleared locally but whose DELETE may not yet be visible to session GETs.
     // Session polls must not restore these flowMap entries (that snaps progress back).
     const pendingClearedFlowIdsRef = useRef<Set<string>>(new Set());
+    // Survives until the next Start creates a new flow — prevents resume from a stale
+    // server flowMap after Clear (intermittent when a late GET reintroduces the mapping).
+    const forceFreshStartFlowIdsRef = useRef<Set<string>>(new Set());
     const [difficultyCache, setDifficultyCache] = useState<SessionCache["sessionDifficulty"]>(
         {} as SessionCache["sessionDifficulty"]
     );
@@ -118,6 +123,9 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
     useEffect(() => {
         dispatch(initializeFlowPage(sessionId));
         sessionDataPrimedRef.current = false;
+        sessionFetchGenRef.current += 1;
+        pendingClearedFlowIdsRef.current.clear();
+        forceFreshStartFlowIdsRef.current.clear();
         return () => {
             dispatch(resetFlowRuntime());
         };
@@ -241,9 +249,16 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
 
     const fetchSessionData = useCallback(
         (options?: { force?: boolean }) => {
+            const fetchGen = sessionFetchGenRef.current;
             triggerGetSessionById({ sessionId })
                 .unwrap()
                 .then((data) => {
+                    // Drop responses that started before a Clear — they can reintroduce
+                    // the old flowMap and make the next Start resume instead of NACK.
+                    if (fetchGen !== sessionFetchGenRef.current) {
+                        return;
+                    }
+
                     let response = data as unknown as SessionCache;
                     // While Start/Stop has written local activeFlow but Redis may still be
                     // stale, keep the optimistic value so a concurrent poll cannot snap the UI back.
@@ -252,29 +267,27 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                         response = { ...response, activeFlow: activeFlowId };
                     }
 
-                    // While Clear is in flight (or a late GET still carries the old mapping),
-                    // keep pending-cleared flows out of local session state so progress cannot
-                    // rehydrate from the prior transaction.
-                    const pendingClears = pendingClearedFlowIdsRef.current;
-                    if (pendingClears.size > 0 && response.flowMap) {
+                    // Keep cleared flows out of local session state until a fresh Start
+                    // consumes the clear — covers both in-flight DELETE lag and late GETs.
+                    const blockedFlowIds = new Set([
+                        ...pendingClearedFlowIdsRef.current,
+                        ...forceFreshStartFlowIdsRef.current,
+                    ]);
+                    if (blockedFlowIds.size > 0 && response.flowMap) {
                         const nextFlowMap = { ...response.flowMap };
                         let nextTransactionIds = [...(response.transactionIds ?? [])];
-                        const resolved: string[] = [];
-                        for (const flowId of pendingClears) {
-                            if (nextFlowMap[flowId]) {
-                                const clearedTxId = nextFlowMap[flowId];
-                                delete nextFlowMap[flowId];
-                                if (clearedTxId) {
-                                    nextTransactionIds = nextTransactionIds.filter(
-                                        (id) => id !== clearedTxId
-                                    );
-                                }
-                            } else {
-                                resolved.push(flowId);
+                        for (const flowId of blockedFlowIds) {
+                            if (!nextFlowMap[flowId]) {
+                                pendingClearedFlowIdsRef.current.delete(flowId);
+                                continue;
                             }
-                        }
-                        for (const flowId of resolved) {
-                            pendingClears.delete(flowId);
+                            const clearedTxId = nextFlowMap[flowId];
+                            delete nextFlowMap[flowId];
+                            if (clearedTxId) {
+                                nextTransactionIds = nextTransactionIds.filter(
+                                    (id) => id !== clearedTxId
+                                );
+                            }
                         }
                         response = {
                             ...response,
@@ -301,6 +314,7 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                     apiCallFailCount.current = 0;
                 })
                 .catch((e: unknown) => {
+                    if (fetchGen !== sessionFetchGenRef.current) return;
                     console.error("Error while fetching session: ", e);
                     apiCallFailCount.current += 1;
                 });
@@ -388,7 +402,11 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
 
     const handleClearFlow = useCallback(
         (flowId: string) => {
+            // Invalidate in-flight session GETs and pin this flow to "fresh start only"
+            // until Start creates a new transaction.
+            sessionFetchGenRef.current += 1;
             pendingClearedFlowIdsRef.current.add(flowId);
+            forceFreshStartFlowIdsRef.current.add(flowId);
             setRequestData(SESSION_EMPTY_RECORD);
             setResponseData(SESSION_EMPTY_RECORD);
             setMetadata(SESSION_EMPTY_METADATA);
@@ -421,6 +439,16 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
         },
         [fetchSessionData]
     );
+
+    const shouldForceFreshStart = useCallback(
+        (flowId: string) => forceFreshStartFlowIdsRef.current.has(flowId),
+        []
+    );
+
+    const handleFreshStartConsumed = useCallback((flowId: string) => {
+        forceFreshStartFlowIdsRef.current.delete(flowId);
+        pendingClearedFlowIdsRef.current.delete(flowId);
+    }, []);
 
     const handleFlowStop = useCallback(() => {
         setIsFlowStopped(true);
@@ -663,6 +691,8 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                                 onFlowStop={handleFlowStop}
                                 onFlowClear={handleClearFlow}
                                 onFlowClearSettled={handleClearFlowSettled}
+                                shouldForceFreshStart={shouldForceFreshStart}
+                                onFreshStartConsumed={handleFreshStartConsumed}
                             />
                         ))}
                     </div>

--- a/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
@@ -352,20 +352,35 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
         filteredFlows = flows;
     }
 
-    const handleClearFlow = useCallback(() => {
-        setRequestData(SESSION_EMPTY_RECORD);
-        setResponseData(SESSION_EMPTY_RECORD);
-        setMetadata(SESSION_EMPTY_METADATA);
-        fetchSessionData();
-    }, [setRequestData, setResponseData, setMetadata, fetchSessionData]);
+    const handleClearFlow = useCallback(
+        (flowId: string) => {
+            setRequestData(SESSION_EMPTY_RECORD);
+            setResponseData(SESSION_EMPTY_RECORD);
+            setMetadata(SESSION_EMPTY_METADATA);
+            // Drop the cleared flow from local session cache immediately so Start
+            // cannot resume from a stale flowMap while the server refresh is in flight.
+            setSessionData((prev) => {
+                if (!prev?.flowMap) return prev;
+                const clearedTxId = prev.flowMap[flowId];
+                const nextFlowMap = { ...prev.flowMap };
+                delete nextFlowMap[flowId];
+                const nextTransactionIds = clearedTxId
+                    ? prev.transactionIds.filter((id) => id !== clearedTxId)
+                    : prev.transactionIds;
+                return {
+                    ...prev,
+                    flowMap: nextFlowMap,
+                    transactionIds: nextTransactionIds,
+                };
+            });
+            fetchSessionData();
+        },
+        [setRequestData, setResponseData, setMetadata, setSessionData, fetchSessionData]
+    );
 
     const handleFlowStop = useCallback(() => {
         setIsFlowStopped(true);
     }, []);
-
-    const handleFlowClear = useCallback(() => {
-        handleClearFlow();
-    }, [handleClearFlow]);
 
     const openSettings = () => {
         setSettingsDraft({
@@ -602,7 +617,7 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                                 setSideView={setSideView as React.Dispatch<unknown>}
                                 subUrl={subUrl}
                                 onFlowStop={handleFlowStop}
-                                onFlowClear={handleFlowClear}
+                                onFlowClear={handleClearFlow}
                             />
                         ))}
                     </div>

--- a/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/RenderFlows/index.tsx
@@ -89,6 +89,9 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
 
     const activeFlowRef = useRef<string | null>(activeFlowId);
     const sessionDataPrimedRef = useRef(false);
+    // Flows cleared locally but whose DELETE may not yet be visible to session GETs.
+    // Session polls must not restore these flowMap entries (that snaps progress back).
+    const pendingClearedFlowIdsRef = useRef<Set<string>>(new Set());
     const [difficultyCache, setDifficultyCache] = useState<SessionCache["sessionDifficulty"]>(
         {} as SessionCache["sessionDifficulty"]
     );
@@ -249,6 +252,37 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                         response = { ...response, activeFlow: activeFlowId };
                     }
 
+                    // While Clear is in flight (or a late GET still carries the old mapping),
+                    // keep pending-cleared flows out of local session state so progress cannot
+                    // rehydrate from the prior transaction.
+                    const pendingClears = pendingClearedFlowIdsRef.current;
+                    if (pendingClears.size > 0 && response.flowMap) {
+                        const nextFlowMap = { ...response.flowMap };
+                        let nextTransactionIds = [...(response.transactionIds ?? [])];
+                        const resolved: string[] = [];
+                        for (const flowId of pendingClears) {
+                            if (nextFlowMap[flowId]) {
+                                const clearedTxId = nextFlowMap[flowId];
+                                delete nextFlowMap[flowId];
+                                if (clearedTxId) {
+                                    nextTransactionIds = nextTransactionIds.filter(
+                                        (id) => id !== clearedTxId
+                                    );
+                                }
+                            } else {
+                                resolved.push(flowId);
+                            }
+                        }
+                        for (const flowId of resolved) {
+                            pendingClears.delete(flowId);
+                        }
+                        response = {
+                            ...response,
+                            flowMap: nextFlowMap,
+                            transactionIds: nextTransactionIds,
+                        };
+                    }
+
                     setDifficultyCache(response.sessionDifficulty);
 
                     const prev = store.getState().session.sessionData;
@@ -354,11 +388,15 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
 
     const handleClearFlow = useCallback(
         (flowId: string) => {
+            pendingClearedFlowIdsRef.current.add(flowId);
             setRequestData(SESSION_EMPTY_RECORD);
             setResponseData(SESSION_EMPTY_RECORD);
             setMetadata(SESSION_EMPTY_METADATA);
             // Drop the cleared flow from local session cache immediately so Start
-            // cannot resume from a stale flowMap while the server refresh is in flight.
+            // cannot resume from a stale flowMap, and so progress cannot rehydrate
+            // via the flowMapEntry → getCurrentState effect. Do NOT refetch yet —
+            // a GET before DELETE settles would restore the old mapping and snap
+            // the progress bar back (requiring a second Clear click).
             setSessionData((prev) => {
                 if (!prev?.flowMap) return prev;
                 const clearedTxId = prev.flowMap[flowId];
@@ -373,9 +411,15 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                     transactionIds: nextTransactionIds,
                 };
             });
-            fetchSessionData();
         },
-        [setRequestData, setResponseData, setMetadata, setSessionData, fetchSessionData]
+        [setRequestData, setResponseData, setMetadata, setSessionData]
+    );
+
+    const handleClearFlowSettled = useCallback(
+        (_flowId: string) => {
+            fetchSessionData({ force: true });
+        },
+        [fetchSessionData]
     );
 
     const handleFlowStop = useCallback(() => {
@@ -618,6 +662,7 @@ function RenderFlows({ flows, subUrl, sessionId, newSession }: IRenderFlowsProps
                                 subUrl={subUrl}
                                 onFlowStop={handleFlowStop}
                                 onFlowClear={handleClearFlow}
+                                onFlowClearSettled={handleClearFlowSettled}
                             />
                         ))}
                     </div>

--- a/frontend/src/components/DomainFlowRunner/types.ts
+++ b/frontend/src/components/DomainFlowRunner/types.ts
@@ -16,6 +16,10 @@ export interface IFlowRunAccordionProps {
     onFlowClear: (flowId: string) => void;
     /** Refetch session after the clear API finishes. */
     onFlowClearSettled: (flowId: string) => void;
+    /** True after Clear until the next Start creates a brand-new flow. */
+    shouldForceFreshStart: (flowId: string) => boolean;
+    /** Call after a forced fresh Start succeeds so later Starts can resume again. */
+    onFreshStartConsumed: (flowId: string) => void;
 }
 
 export interface IRenderFlowsProps {

--- a/frontend/src/components/DomainFlowRunner/types.ts
+++ b/frontend/src/components/DomainFlowRunner/types.ts
@@ -12,7 +12,10 @@ export interface IFlowRunAccordionProps {
     setSideView: React.Dispatch<unknown>;
     subUrl: string;
     onFlowStop: () => void;
+    /** Optimistically drop local flowMap entry — do not refetch yet. */
     onFlowClear: (flowId: string) => void;
+    /** Refetch session after the clear API finishes. */
+    onFlowClearSettled: (flowId: string) => void;
 }
 
 export interface IRenderFlowsProps {

--- a/frontend/src/components/DomainFlowRunner/types.ts
+++ b/frontend/src/components/DomainFlowRunner/types.ts
@@ -12,7 +12,7 @@ export interface IFlowRunAccordionProps {
     setSideView: React.Dispatch<unknown>;
     subUrl: string;
     onFlowStop: () => void;
-    onFlowClear: () => void;
+    onFlowClear: (flowId: string) => void;
 }
 
 export interface IRenderFlowsProps {


### PR DESCRIPTION
## Summary
- Fixes Flow Testing so **Clear Flow** fully resets execution state; re-running always starts from 0% instead of occasionally resuming prior progress.
- Root cause: Stop released the UI before its session write finished, so Clear could race with a stop `putCacheData` read-modify-write that restored `flowMap`, while Start also resumed from a stale local session cache.

## Changes
- **Stop**: keep Clear blocked until `putCacheData({ activeFlow: "NONE" })` completes.
- **Clear**: optimistically remove the flow from local `flowMap` / `transactionIds`; backend `clearFlowService` deletes the mapping, drops transaction cache, and re-applies clear if a concurrent update restored it.
- **Start**: fetch the latest session before deciding resume vs new flow.

## Reason
cleared flows must always restart from a fresh execution.