### PR TITLE
Auto-detect seller form URL in reference_data for HTML forms

### DIFF
--- a/frontend/src/components/Forms/custom-forms/protocol-html-form.tsx
+++ b/frontend/src/components/Forms/custom-forms/protocol-html-form.tsx
@@ -318,16 +318,35 @@ export default function ProtocolHTMLForm({
     contractContext,
     transactionId,
 }: IProtocolHtmlFormProps) {
-    // Resolve the seller form URL (only used when htmlSource === "url")
-    const formUrl = useMemo<string>(() => {
+    // Value the step's `reference` points at. Normally embedded HTML, but when the upstream
+    // service saved the xinput.form.url without fetching it, it is the seller URL itself.
+    const referencedValue = useMemo<string>(() => {
         const value = queryJsonPath(
             { reference_data: referenceData },
-            HtmlFormConfigInFlow.urlReference || ""
+            HtmlFormConfigInFlow.reference || ""
         )[0];
         return typeof value === "string" ? value : "";
-    }, [referenceData, HtmlFormConfigInFlow.urlReference]);
+    }, [referenceData, HtmlFormConfigInFlow.reference]);
 
-    const useUrl = HtmlFormConfigInFlow.htmlSource === "url" && !!formUrl;
+    // Resolve the seller form URL: explicit url mode uses `urlReference`; otherwise auto-detect a
+    // URL sitting where HTML was expected and fetch it instead of parsing the URL string as HTML.
+    const formUrl = useMemo<string>(() => {
+        if (HtmlFormConfigInFlow.htmlSource === "url") {
+            const value = queryJsonPath(
+                { reference_data: referenceData },
+                HtmlFormConfigInFlow.urlReference || ""
+            )[0];
+            return typeof value === "string" ? value : "";
+        }
+        return /^https?:\/\/\S+$/i.test(referencedValue.trim()) ? referencedValue.trim() : "";
+    }, [
+        referenceData,
+        HtmlFormConfigInFlow.htmlSource,
+        HtmlFormConfigInFlow.urlReference,
+        referencedValue,
+    ]);
+
+    const useUrl = !!formUrl;
 
     // Fetch the seller-hosted form HTML through the backend proxy (browser can't, due to CORS)
     const {
@@ -339,12 +358,8 @@ export default function ProtocolHTMLForm({
     // HTML source: fetched seller form (url mode) or embedded reference_data (default)
     const formHtml = useMemo<string>(() => {
         if (useUrl) return typeof fetchedHtml === "string" ? fetchedHtml : "";
-        const value = queryJsonPath(
-            { reference_data: referenceData },
-            HtmlFormConfigInFlow.reference || ""
-        )[0];
-        return typeof value === "string" ? value : "";
-    }, [useUrl, fetchedHtml, referenceData, HtmlFormConfigInFlow.reference]);
+        return referencedValue;
+    }, [useUrl, fetchedHtml, referencedValue]);
 
     // Query params carried on the seller URL, used to back-fill empty hidden fields
     const urlParams = useMemo<Record<string, string>>(() => {


### PR DESCRIPTION
## Summary

Follow-up to #719. When testing against a live seller NP, `reference_data` for an HTML_FORM step can end up holding the **seller form URL** instead of the fetched HTML (the upstream service saves `xinput.form.url` without swapping it for the form body). The workbench modal then showed:

> Seller form issue (1) — Flow reference_data holds a body with no HTML markup (likely a plain-text or JSON error response).

Observed on the motor renewal journey with a seller-hosted `renew_vehicle_details.html` form.

## Change

`ProtocolHTMLForm` now detects when the step's `reference` resolves to an `http(s)://` URL and switches itself into url mode:

- fetches the seller form through the existing backend proxy (same path as explicit `htmlSource: "url"` steps, avoiding CORS)
- shows the existing loading / fetch-failed states
- then reuses the existing parsing, contract-validation, rendering, and submission logic unchanged — query params on the URL back-fill hidden fields, and contract issues are reported with the "Seller returned…" wording since the source is genuinely the seller

Steps with explicit `htmlSource: "url"` and steps with embedded HTML behave exactly as before.

## Test plan

- `tsc -b`, eslint, prettier clean (pre-commit hooks)
- Verified against the live seller form URL: response parses and renders; with the fix the modal renders the seller form fields instead of the "no HTML markup" error
