### PR TITLE
fix(ride-map): stop treating on_update as a map-driven step

### DIFF
--- a/frontend/src/components/DomainFlowRunner/MappedFlow/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/MappedFlow/index.tsx
@@ -139,13 +139,13 @@ export default function DisplayFlow({
     // --- Real-Time Ride Map Integration ------------------------------------
     // The map UI now lives in the right-panel "Application" tab (RideMapTab). Here we only need to
     // know whether the tracking phase is active, to stop the flow engine auto-proceeding the ride
-    // states — the seller drives on_status/on_update manually from the map. Tracking activates only
+    // states — the seller drives on_status manually from the map. Tracking activates only
     // once the driver is assigned AND the initial location is shared (a track/on_track step is
     // COMPLETE) — NOT at on_confirm, so pre-assignment steps (e.g. the unsolicited on_update driver
     // assignment in "assign driver post on_confirm" flows) still auto-proceed normally.
     // IMPORTANT: this engine override must apply ONLY for the ride-map domain/version (TRV10 2.1.0).
     // For every other domain `trackingActive` stays false, so the normal auto-proceed behaviour of
-    // track/on_track/on_status/on_update/status is fully preserved and their flows are unaffected.
+    // track/on_track/on_status/status is fully preserved and their flows are unaffected.
     const trackingActive =
         isRideMapEnabled(sessionData?.domain, sessionData?.version) && isTrackingActive(mappedFlow);
 
@@ -208,7 +208,8 @@ export default function DisplayFlow({
         // track/on_track complete), it is fully manual — do NOT auto-open/auto-submit input for
         // track/on_track/on_status/etc. The seller advances these via the map controls.
         // (Pre-tracking steps like the on_update driver assignment and on_track_on_assign are not
-        // suppressed — tracking only activates once they complete.)
+        // suppressed — tracking only activates once they complete. on_update is outside the set
+        // entirely, so an on_update carrying its own form still opens its dialog.)
         if (trackingActive && isTrackingPhaseStep(target?.actionType)) return;
         // Extra steps must be advanced via triggerExtra (carries `trigger_extra`); use the step's
         // actionId as the trigger key. Undefined => sequence step => proceedFlow.

--- a/frontend/src/components/DomainFlowRunner/RideMapTab/index.tsx
+++ b/frontend/src/components/DomainFlowRunner/RideMapTab/index.tsx
@@ -123,7 +123,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
 
     // `code` is the RIDE_* fulfillment-state code (the button values are the codes themselves).
     // Each state change advances the flow through the NORMAL proceed API: the next pending
-    // tracking-phase sequence step (on_status/on_update) is dispatched by passing its actionId as
+    // ride-state sequence step (on_status) is dispatched by passing its actionId as
     // `inputs.id` — no trigger_extra. Returns true only when the step was actually dispatched to
     // the buyer — callers gate the driver animation on this so movement never starts before the
     // buyer is updated.
@@ -279,7 +279,7 @@ export default function RideMapTab({ flowId }: { flowId: string | null }) {
     };
 
     // Enroute → animate to pickup → auto Arrived. Started → animate to drop → auto End+Completed.
-    // The driver animation starts ONLY after the on_status/on_update is acknowledged (sendRideState
+    // The driver animation starts ONLY after the on_status is acknowledged (sendRideState
     // returns true) — i.e. the buyer has actually been updated. A failed/undelivered send aborts.
     const handleRideState = async (code: string) => {
         if (code === "RIDE_ENROUTE_PICKUP") {

--- a/frontend/src/components/DomainFlowRunner/RideMapUtils/index.ts
+++ b/frontend/src/components/DomainFlowRunner/RideMapUtils/index.ts
@@ -345,15 +345,17 @@ export function nextPendingRideState(mappedFlow: FlowMap): RideState | undefined
 }
 
 /**
- * The actionId of the next not-yet-complete tracking-phase step (on_status/on_update) in the
- * sequence — passed as `inputs.id` to the normal proceed API so the flow engine dispatches that
- * step (manual steps require `inputs.id === actionId`).
+ * The actionId of the next not-yet-complete ride-state step (`on_status`) in the sequence —
+ * passed as `inputs.id` to the normal proceed API so the flow engine dispatches that step
+ * (manual steps require `inputs.id === actionId`).
+ *
+ * `on_update` is not matched: the map has no control for those, so it must not claim to drive
+ * them. Note the engine dispatches whichever step is actually next in the sequence, so an
+ * intervening on_update still receives the press — it just isn't named here.
  */
 export function nextPendingTrackingActionId(mappedFlow: FlowMap): string | undefined {
     const step = (mappedFlow.sequence ?? []).find(
-        (s) =>
-            (s.actionType === "on_status" || s.actionType === "on_update") &&
-            s.status !== "COMPLETE"
+        (s) => s.actionType === "on_status" && s.status !== "COMPLETE"
     );
     return step?.actionId;
 }
@@ -372,8 +374,15 @@ export function currentRideState(mappedFlow: FlowMap): string | undefined {
     return state;
 }
 
-/** Step types that belong to the tracking phase (after on_confirm) and must NOT auto-proceed. */
-const TRACKING_PHASE_TYPES = new Set(["track", "on_track", "on_status", "on_update", "status"]);
+/**
+ * Step types that belong to the tracking phase (after on_confirm) and must NOT auto-proceed.
+ *
+ * `on_update` is deliberately absent. It used to carry the RIDE_ENDED notification, but every
+ * RIDE_* progression step is an `on_status` now, so no on_update is a map-driven ride state:
+ * the remaining ones are pre-tracking driver assignment or responses to an `update`. Keeping it
+ * here suppressed the input dialog of any on_update that legitimately carries its own form.
+ */
+const TRACKING_PHASE_TYPES = new Set(["track", "on_track", "on_status", "status"]);
 export const isTrackingPhaseStep = (actionType?: string): boolean =>
     !!actionType && TRACKING_PHASE_TYPES.has(actionType);
 


### PR DESCRIPTION
An on_update carrying its own input form never showed it — the flow just sent. Once the tracking phase is active, MappedFlow suppresses the input dialog for any step whose type is in TRACKING_PHASE_TYPES, and on_update was in that set. isTrackingActive flips true as soon as the first track/on_track completes, so every later on_update was silently swallowed and advanced by the Ride Map's ride-state buttons with no form data.

on_update was in the set because the RIDE_ENDED notification used to be an on_update. Every RIDE_* progression step is an on_status now, so no on_update is a map-driven ride state any more: across the 27 TRV10 flows the remaining ones are pre-tracking driver assignment (on_update_ride, on_update_ride_self_pickup, on_update_ride_assigned) or responses to an update (on_update_soft_update, on_update_payment, on_update_quote, on_update_ride_updated).

Removes on_update from TRACKING_PHASE_TYPES, and from nextPendingTrackingActionId so the map no longer claims to drive steps it has no control for. Comments updated to match.

Blast radius checked against every on_update step in the suite: the 5 pre-tracking ones run before trackingActive is true, so neither guard ever applied to them; the 6 solicited ones resolve to RESPONDING, which the input guard never selects and which the auto-proceed guard only touches when force_proceed is set — and force_proceed appears zero times across all 27 flow specs. trackingActive is also gated by isRideMapEnabled(TRV10 2.1.0), so no other domain is reachable. Net effect today is one step: OnDemand_Assign_driver_on_onconfirm's on_update_fare_charges now opens its dialog.

deriveRideMapData still reads on_update in ORDER_ACTIONS — that is how the map sees the post-confirm driver assignment and soft states, and removing it there would blank the driver panel in five flows. It reads state for display; it does not drive steps.

tsc --noEmit and eslint clean.

## What does this PR do?
<!-- Describe the change clearly. One line is fine for small fixes. -->

## Type of change
- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] hotfix — urgent production fix
- [ ] chore — maintenance, deps, config
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — adding or fixing tests

## How has this been tested?
<!-- Unit tests / manual steps / postman collection -->

## Checklist
- [ ] My PR title follows the format: `type: short description`
- [ ] I have added/updated tests
- [ ] No console logs or debug code left in
- [ ] Linked issue below

## Related issue
Closes #
